### PR TITLE
Promoting `ParseResourceID` to a top level function

### DIFF
--- a/storage/2017-07-29/blob/blobs/resource_id.go
+++ b/storage/2017-07-29/blob/blobs/resource_id.go
@@ -23,7 +23,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the Resource ID and returns an object which can be used
 // to interact with the Blob Resource
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://foo.blob.core.windows.net/Bar/example.vhd
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2017-07-29/blob/blobs/resource_id_test.go
+++ b/storage/2017-07-29/blob/blobs/resource_id_test.go
@@ -63,8 +63,7 @@ func TestParseResourceID(t *testing.T) {
 	t.Logf("[DEBUG] Top Level Files")
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -104,8 +103,7 @@ func TestParseResourceID(t *testing.T) {
 	t.Logf("[DEBUG] Nested Files")
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2017-07-29/blob/containers/resource_id.go
+++ b/storage/2017-07-29/blob/containers/resource_id.go
@@ -22,7 +22,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the Resource ID and returns an object which can be used
 // to interact with the Container Resource
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://foo.blob.core.windows.net/Bar
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2017-07-29/blob/containers/resource_id_test.go
+++ b/storage/2017-07-29/blob/containers/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2017-07-29/file/directories/resource_id.go
+++ b/storage/2017-07-29/file/directories/resource_id.go
@@ -23,7 +23,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the Resource ID into an Object
 // which can be used to interact with the Directory within the File Share
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://foo.file.core.windows.net/Bar/Folder
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2017-07-29/file/directories/resource_id_test.go
+++ b/storage/2017-07-29/file/directories/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2017-07-29/file/files/resource_id.go
+++ b/storage/2017-07-29/file/files/resource_id.go
@@ -24,7 +24,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the specified Resource ID and returns an object
 // which can be used to interact with Files within a Storage Share.
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://account1.file.core.chinacloudapi.cn/share1/directory1/file1.txt
 	// example: https://account1.file.core.chinacloudapi.cn/share1/directory1/directory2/file1.txt
 

--- a/storage/2017-07-29/file/files/resource_id_test.go
+++ b/storage/2017-07-29/file/files/resource_id_test.go
@@ -64,8 +64,7 @@ func TestParseResourceID(t *testing.T) {
 	t.Logf("[DEBUG] Top Level Files")
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -109,8 +108,7 @@ func TestParseResourceID(t *testing.T) {
 	t.Logf("[DEBUG] Nested Files")
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2017-07-29/file/shares/resource_id.go
+++ b/storage/2017-07-29/file/shares/resource_id.go
@@ -22,7 +22,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the specified Resource ID and returns an object
 // which can be used to interact with the Storage Shares SDK
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://foo.file.core.windows.net/Bar
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2017-07-29/file/shares/resource_id_test.go
+++ b/storage/2017-07-29/file/shares/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2017-07-29/queue/messages/resource_id.go
+++ b/storage/2017-07-29/queue/messages/resource_id.go
@@ -23,7 +23,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the specified Resource ID and returns an object
 // which can be used to interact with the Message within a Queue
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://account1.queue.core.chinacloudapi.cn/queue1/messages/message1
 
 	if id == "" {

--- a/storage/2017-07-29/queue/messages/resource_id_test.go
+++ b/storage/2017-07-29/queue/messages/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2017-07-29/queue/queues/resource_id.go
+++ b/storage/2017-07-29/queue/queues/resource_id.go
@@ -22,7 +22,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the Resource ID and returns an Object which
 // can be used to interact with a Queue within a Storage Account
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://foo.queue.core.windows.net/Bar
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2017-07-29/queue/queues/resource_id_test.go
+++ b/storage/2017-07-29/queue/queues/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2017-07-29/table/entities/resource_id.go
+++ b/storage/2017-07-29/table/entities/resource_id.go
@@ -24,7 +24,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the specified Resource ID and returns an object which
 // can be used to look up the specified Entity within the specified Table
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://account1.table.core.chinacloudapi.cn/table1(PartitionKey='partition1',RowKey='row1')
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2017-07-29/table/entities/resource_id_test.go
+++ b/storage/2017-07-29/table/entities/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2017-07-29/table/tables/resource_id.go
+++ b/storage/2017-07-29/table/tables/resource_id.go
@@ -22,7 +22,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the Resource ID and returns an object which
 // can be used to interact with the Table within the specified Storage Account
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://foo.table.core.windows.net/Table('foo')
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2017-07-29/table/tables/resource_id_test.go
+++ b/storage/2017-07-29/table/tables/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2018-03-28/blob/blobs/resource_id.go
+++ b/storage/2018-03-28/blob/blobs/resource_id.go
@@ -23,7 +23,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the Resource ID and returns an object which can be used
 // to interact with the Blob Resource
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://foo.blob.core.windows.net/Bar/example.vhd
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2018-03-28/blob/blobs/resource_id_test.go
+++ b/storage/2018-03-28/blob/blobs/resource_id_test.go
@@ -63,8 +63,7 @@ func TestParseResourceID(t *testing.T) {
 	t.Logf("[DEBUG] Top Level Files")
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -104,8 +103,7 @@ func TestParseResourceID(t *testing.T) {
 	t.Logf("[DEBUG] Nested Files")
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2018-03-28/blob/containers/resource_id.go
+++ b/storage/2018-03-28/blob/containers/resource_id.go
@@ -22,7 +22,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the Resource ID and returns an object which can be used
 // to interact with the Container Resource
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://foo.blob.core.windows.net/Bar
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2018-03-28/blob/containers/resource_id_test.go
+++ b/storage/2018-03-28/blob/containers/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2018-03-28/file/directories/resource_id.go
+++ b/storage/2018-03-28/file/directories/resource_id.go
@@ -23,7 +23,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the Resource ID into an Object
 // which can be used to interact with the Directory within the File Share
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://foo.file.core.windows.net/Bar/Folder
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2018-03-28/file/directories/resource_id_test.go
+++ b/storage/2018-03-28/file/directories/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2018-03-28/file/files/resource_id.go
+++ b/storage/2018-03-28/file/files/resource_id.go
@@ -24,7 +24,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the specified Resource ID and returns an object
 // which can be used to interact with Files within a Storage Share.
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://account1.file.core.chinacloudapi.cn/share1/directory1/file1.txt
 	// example: https://account1.file.core.chinacloudapi.cn/share1/directory1/directory2/file1.txt
 

--- a/storage/2018-03-28/file/files/resource_id_test.go
+++ b/storage/2018-03-28/file/files/resource_id_test.go
@@ -64,8 +64,7 @@ func TestParseResourceID(t *testing.T) {
 	t.Logf("[DEBUG] Top Level Files")
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -109,8 +108,7 @@ func TestParseResourceID(t *testing.T) {
 	t.Logf("[DEBUG] Nested Files")
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2018-03-28/file/shares/resource_id.go
+++ b/storage/2018-03-28/file/shares/resource_id.go
@@ -22,7 +22,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the specified Resource ID and returns an object
 // which can be used to interact with the Storage Shares SDK
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://foo.file.core.windows.net/Bar
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2018-03-28/file/shares/resource_id_test.go
+++ b/storage/2018-03-28/file/shares/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2018-03-28/queue/messages/resource_id.go
+++ b/storage/2018-03-28/queue/messages/resource_id.go
@@ -23,7 +23,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the specified Resource ID and returns an object
 // which can be used to interact with the Message within a Queue
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://account1.queue.core.chinacloudapi.cn/queue1/messages/message1
 
 	if id == "" {

--- a/storage/2018-03-28/queue/messages/resource_id_test.go
+++ b/storage/2018-03-28/queue/messages/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2018-03-28/queue/queues/resource_id.go
+++ b/storage/2018-03-28/queue/queues/resource_id.go
@@ -22,7 +22,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the Resource ID and returns an Object which
 // can be used to interact with a Queue within a Storage Account
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://foo.queue.core.windows.net/Bar
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2018-03-28/queue/queues/resource_id_test.go
+++ b/storage/2018-03-28/queue/queues/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2018-03-28/table/entities/resource_id.go
+++ b/storage/2018-03-28/table/entities/resource_id.go
@@ -24,7 +24,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the specified Resource ID and returns an object which
 // can be used to look up the specified Entity within the specified Table
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://account1.table.core.chinacloudapi.cn/table1(PartitionKey='partition1',RowKey='row1')
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2018-03-28/table/entities/resource_id_test.go
+++ b/storage/2018-03-28/table/entities/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2018-03-28/table/tables/resource_id.go
+++ b/storage/2018-03-28/table/tables/resource_id.go
@@ -22,7 +22,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the Resource ID and returns an object which
 // can be used to interact with the Table within the specified Storage Account
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://foo.table.core.windows.net/Table('foo')
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2018-03-28/table/tables/resource_id_test.go
+++ b/storage/2018-03-28/table/tables/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2018-11-09/blob/blobs/resource_id.go
+++ b/storage/2018-11-09/blob/blobs/resource_id.go
@@ -23,7 +23,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the Resource ID and returns an object which can be used
 // to interact with the Blob Resource
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://foo.blob.core.windows.net/Bar/example.vhd
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2018-11-09/blob/blobs/resource_id_test.go
+++ b/storage/2018-11-09/blob/blobs/resource_id_test.go
@@ -63,8 +63,7 @@ func TestParseResourceID(t *testing.T) {
 	t.Logf("[DEBUG] Top Level Files")
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -104,8 +103,7 @@ func TestParseResourceID(t *testing.T) {
 	t.Logf("[DEBUG] Nested Files")
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2018-11-09/blob/containers/resource_id.go
+++ b/storage/2018-11-09/blob/containers/resource_id.go
@@ -22,7 +22,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the Resource ID and returns an object which can be used
 // to interact with the Container Resource
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://foo.blob.core.windows.net/Bar
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2018-11-09/blob/containers/resource_id_test.go
+++ b/storage/2018-11-09/blob/containers/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2018-11-09/file/directories/resource_id.go
+++ b/storage/2018-11-09/file/directories/resource_id.go
@@ -23,7 +23,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the Resource ID into an Object
 // which can be used to interact with the Directory within the File Share
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://foo.file.core.windows.net/Bar/Folder
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2018-11-09/file/directories/resource_id_test.go
+++ b/storage/2018-11-09/file/directories/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2018-11-09/file/files/resource_id.go
+++ b/storage/2018-11-09/file/files/resource_id.go
@@ -24,7 +24,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the specified Resource ID and returns an object
 // which can be used to interact with Files within a Storage Share.
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://account1.file.core.chinacloudapi.cn/share1/directory1/file1.txt
 	// example: https://account1.file.core.chinacloudapi.cn/share1/directory1/directory2/file1.txt
 

--- a/storage/2018-11-09/file/files/resource_id_test.go
+++ b/storage/2018-11-09/file/files/resource_id_test.go
@@ -64,8 +64,7 @@ func TestParseResourceID(t *testing.T) {
 	t.Logf("[DEBUG] Top Level Files")
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -109,8 +108,7 @@ func TestParseResourceID(t *testing.T) {
 	t.Logf("[DEBUG] Nested Files")
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2018-11-09/file/shares/resource_id.go
+++ b/storage/2018-11-09/file/shares/resource_id.go
@@ -22,7 +22,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the specified Resource ID and returns an object
 // which can be used to interact with the Storage Shares SDK
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://foo.file.core.windows.net/Bar
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2018-11-09/file/shares/resource_id_test.go
+++ b/storage/2018-11-09/file/shares/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2018-11-09/queue/messages/resource_id.go
+++ b/storage/2018-11-09/queue/messages/resource_id.go
@@ -23,7 +23,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the specified Resource ID and returns an object
 // which can be used to interact with the Message within a Queue
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://account1.queue.core.chinacloudapi.cn/queue1/messages/message1
 
 	if id == "" {

--- a/storage/2018-11-09/queue/messages/resource_id_test.go
+++ b/storage/2018-11-09/queue/messages/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2018-11-09/queue/queues/resource_id.go
+++ b/storage/2018-11-09/queue/queues/resource_id.go
@@ -22,7 +22,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the Resource ID and returns an Object which
 // can be used to interact with a Queue within a Storage Account
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://foo.queue.core.windows.net/Bar
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2018-11-09/queue/queues/resource_id_test.go
+++ b/storage/2018-11-09/queue/queues/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2018-11-09/table/entities/resource_id.go
+++ b/storage/2018-11-09/table/entities/resource_id.go
@@ -24,7 +24,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the specified Resource ID and returns an object which
 // can be used to look up the specified Entity within the specified Table
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://account1.table.core.chinacloudapi.cn/table1(PartitionKey='partition1',RowKey='row1')
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2018-11-09/table/entities/resource_id_test.go
+++ b/storage/2018-11-09/table/entities/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/storage/2018-11-09/table/tables/resource_id.go
+++ b/storage/2018-11-09/table/tables/resource_id.go
@@ -22,7 +22,7 @@ type ResourceID struct {
 
 // ParseResourceID parses the Resource ID and returns an object which
 // can be used to interact with the Table within the specified Storage Account
-func (client Client) ParseResourceID(id string) (*ResourceID, error) {
+func ParseResourceID(id string) (*ResourceID, error) {
 	// example: https://foo.table.core.windows.net/Table('foo')
 	if id == "" {
 		return nil, fmt.Errorf("`id` was empty")

--- a/storage/2018-11-09/table/tables/resource_id_test.go
+++ b/storage/2018-11-09/table/tables/resource_id_test.go
@@ -62,8 +62,7 @@ func TestParseResourceID(t *testing.T) {
 	}
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
-		c := NewWithEnvironment(v.Environment)
-		actual, err := c.ParseResourceID(v.Input)
+		actual, err := ParseResourceID(v.Input)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Whilst `GetResourceID` makes sense as a function on the Client - after playing around with it `ParseResourceID` needs to exist as a top-level function in it's own right

Since this is technically a breaking change this'll library will need to go to 0.2.0