### PR TITLE
shares: conditionally parsing the quota

### DIFF
--- a/storage/2017-07-29/file/shares/properties_get.go
+++ b/storage/2017-07-29/file/shares/properties_get.go
@@ -93,11 +93,13 @@ func (client Client) GetPropertiesResponder(resp *http.Response) (result GetProp
 		result.MetaData = metadata.ParseFromHeaders(resp.Header)
 
 		quotaRaw := resp.Header.Get("x-ms-share-quota")
-		quota, e := strconv.Atoi(quotaRaw)
-		if e != nil {
-			return result, fmt.Errorf("Error converting %q to an integer: %s", quotaRaw, err)
+		if quotaRaw != "" {
+			quota, e := strconv.Atoi(quotaRaw)
+			if e != nil {
+				return result, fmt.Errorf("Error converting %q to an integer: %s", quotaRaw, err)
+			}
+			result.ShareQuota = quota
 		}
-		result.ShareQuota = quota
 	}
 
 	err = autorest.Respond(

--- a/storage/2018-03-28/file/shares/properties_get.go
+++ b/storage/2018-03-28/file/shares/properties_get.go
@@ -93,11 +93,13 @@ func (client Client) GetPropertiesResponder(resp *http.Response) (result GetProp
 		result.MetaData = metadata.ParseFromHeaders(resp.Header)
 
 		quotaRaw := resp.Header.Get("x-ms-share-quota")
-		quota, e := strconv.Atoi(quotaRaw)
-		if e != nil {
-			return result, fmt.Errorf("Error converting %q to an integer: %s", quotaRaw, err)
+		if quotaRaw != "" {
+			quota, e := strconv.Atoi(quotaRaw)
+			if e != nil {
+				return result, fmt.Errorf("Error converting %q to an integer: %s", quotaRaw, err)
+			}
+			result.ShareQuota = quota
 		}
-		result.ShareQuota = quota
 	}
 
 	err = autorest.Respond(

--- a/storage/2018-11-09/file/shares/properties_get.go
+++ b/storage/2018-11-09/file/shares/properties_get.go
@@ -93,11 +93,13 @@ func (client Client) GetPropertiesResponder(resp *http.Response) (result GetProp
 		result.MetaData = metadata.ParseFromHeaders(resp.Header)
 
 		quotaRaw := resp.Header.Get("x-ms-share-quota")
-		quota, e := strconv.Atoi(quotaRaw)
-		if e != nil {
-			return result, fmt.Errorf("Error converting %q to an integer: %s", quotaRaw, err)
+		if quotaRaw != "" {
+			quota, e := strconv.Atoi(quotaRaw)
+			if e != nil {
+				return result, fmt.Errorf("Error converting %q to an integer: %s", quotaRaw, err)
+			}
+			result.ShareQuota = quota
 		}
-		result.ShareQuota = quota
 	}
 
 	err = autorest.Respond(


### PR DESCRIPTION
When retrieving the properties for a Share which has been deleted, the Quota header isn't returned, which results in the following error:

```
shares.Client#GetProperties: Failure responding to request: StatusCode=404 -- Original Error: Error converting "" to an integer: %!s(<nil>)
```

This PR conditionally parses the Quota value from the header providing it's not an empty string