### PR TITLE
Add multiple cors rules

### DIFF
--- a/storage/2018-03-28/queue/queues/models.go
+++ b/storage/2018-03-28/queue/queues/models.go
@@ -30,7 +30,7 @@ type RetentionPolicy struct {
 }
 
 type Cors struct {
-	CorsRule CorsRule `xml:"CorsRule"`
+	CorsRule []CorsRule `xml:"CorsRule"`
 }
 
 type CorsRule struct {

--- a/storage/2018-11-09/queue/queues/models.go
+++ b/storage/2018-11-09/queue/queues/models.go
@@ -30,7 +30,7 @@ type RetentionPolicy struct {
 }
 
 type Cors struct {
-	CorsRule CorsRule `xml:"CorsRule"`
+	CorsRule []CorsRule `xml:"CorsRule"`
 }
 
 type CorsRule struct {


### PR DESCRIPTION
Adding ability to set and remove multiple cors rules. The API allows for 5 to be set. 

```
--- PASS: TestQueuesLifecycle (89.84s)
--- PASS: TestParseResourceID (0.00s)
```