### PR TITLE
Queues: specifying a path parameter

### DIFF
--- a/storage/2018-03-28/queue/queues/properties_get.go
+++ b/storage/2018-03-28/queue/queues/properties_get.go
@@ -58,6 +58,7 @@ func (client Client) GetServicePropertiesPreparer(ctx context.Context, accountNa
 		autorest.AsContentType("application/xml; charset=utf-8"),
 		autorest.AsGet(),
 		autorest.WithBaseURL(endpoints.GetQueueEndpoint(client.BaseURI, accountName)),
+		autorest.WithPath("/"),
 		autorest.WithQueryParameters(queryParameters),
 		autorest.WithHeaders(headers))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))

--- a/storage/2018-03-28/queue/queues/properties_get.go
+++ b/storage/2018-03-28/queue/queues/properties_get.go
@@ -18,25 +18,25 @@ type StorageServicePropertiesResponse struct {
 // SetServiceProperties gets the properties for this queue
 func (client Client) GetServiceProperties(ctx context.Context, accountName string) (result StorageServicePropertiesResponse, err error) {
 	if accountName == "" {
-		return result, validation.NewError("queues.Client", "SetServiceProperties", "`accountName` cannot be an empty string.")
+		return result, validation.NewError("queues.Client", "GetServiceProperties", "`accountName` cannot be an empty string.")
 	}
 
 	req, err := client.GetServicePropertiesPreparer(ctx, accountName)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "queues.Client", "SetServiceProperties", nil, "Failure preparing request")
+		err = autorest.NewErrorWithError(err, "queues.Client", "GetServiceProperties", nil, "Failure preparing request")
 		return
 	}
 
 	resp, err := client.GetServicePropertiesSender(req)
 	if err != nil {
 		result.Response = autorest.Response{Response: resp}
-		err = autorest.NewErrorWithError(err, "queues.Client", "SetServiceProperties", resp, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "queues.Client", "GetServiceProperties", resp, "Failure sending request")
 		return
 	}
 
 	result, err = client.GetServicePropertiesResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "queues.Client", "SetServiceProperties", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "queues.Client", "GetServiceProperties", resp, "Failure responding to request")
 		return
 	}
 

--- a/storage/2018-11-09/queue/queues/properties_get.go
+++ b/storage/2018-11-09/queue/queues/properties_get.go
@@ -58,6 +58,7 @@ func (client Client) GetServicePropertiesPreparer(ctx context.Context, accountNa
 		autorest.AsContentType("application/xml; charset=utf-8"),
 		autorest.AsGet(),
 		autorest.WithBaseURL(endpoints.GetQueueEndpoint(client.BaseURI, accountName)),
+		autorest.WithPath("/"),
 		autorest.WithQueryParameters(queryParameters),
 		autorest.WithHeaders(headers))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))

--- a/storage/2018-11-09/queue/queues/properties_get.go
+++ b/storage/2018-11-09/queue/queues/properties_get.go
@@ -18,25 +18,25 @@ type StorageServicePropertiesResponse struct {
 // SetServiceProperties gets the properties for this queue
 func (client Client) GetServiceProperties(ctx context.Context, accountName string) (result StorageServicePropertiesResponse, err error) {
 	if accountName == "" {
-		return result, validation.NewError("queues.Client", "SetServiceProperties", "`accountName` cannot be an empty string.")
+		return result, validation.NewError("queues.Client", "GetServiceProperties", "`accountName` cannot be an empty string.")
 	}
 
 	req, err := client.GetServicePropertiesPreparer(ctx, accountName)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "queues.Client", "SetServiceProperties", nil, "Failure preparing request")
+		err = autorest.NewErrorWithError(err, "queues.Client", "GetServiceProperties", nil, "Failure preparing request")
 		return
 	}
 
 	resp, err := client.GetServicePropertiesSender(req)
 	if err != nil {
 		result.Response = autorest.Response{Response: resp}
-		err = autorest.NewErrorWithError(err, "queues.Client", "SetServiceProperties", resp, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "queues.Client", "GetServiceProperties", resp, "Failure sending request")
 		return
 	}
 
 	result, err = client.GetServicePropertiesResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "queues.Client", "SetServiceProperties", resp, "Failure responding to request")
+		err = autorest.NewErrorWithError(err, "queues.Client", "GetServiceProperties", resp, "Failure responding to request")
 		return
 	}
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Number = "v0.0.1"
+const Number = "v0.3.1"


### PR DESCRIPTION
Turns out that https://github.com/Azure/go-autorest doesn't automatically specify a path of `/` if one isn't specified - which means the strings computed for the authentication header can be wrong - since we were producing:

```
GET

application/xml; charset=utf-8

x-ms-date:Wed, 21 Aug 2019 11:53:48 GMT
x-ms-version:2018-11-09
/unlikely23exst2accti1t0?comp=properties
```

when Azure was expecting:

```
GET

application/xml; charset=utf-8

x-ms-date:Wed, 21 Aug 2019 11:53:48 GMT
x-ms-version:2018-11-09
/unlikely23exst2accti1t0/?comp=properties
```

(note the missing `/`)

This PR adds a default path of `/` to the `GetServiceProperties` method in the QueuesClient so that this works as expected

This bug only affects when using a SharedKeyLite to authenticate, which is why we didn't see this before