### PR TITLE
queues: setting a path for properties

### DIFF
--- a/storage/2018-03-28/queue/queues/properties_set.go
+++ b/storage/2018-03-28/queue/queues/properties_set.go
@@ -53,6 +53,7 @@ func (client Client) SetServicePropertiesPreparer(ctx context.Context, accountNa
 		autorest.AsContentType("application/xml; charset=utf-8"),
 		autorest.AsPut(),
 		autorest.WithBaseURL(endpoints.GetQueueEndpoint(client.BaseURI, accountName)),
+		autorest.WithPath("/"),
 		autorest.WithQueryParameters(queryParameters),
 		autorest.WithXML(properties),
 		autorest.WithHeaders(headers))

--- a/storage/2018-11-09/queue/queues/properties_set.go
+++ b/storage/2018-11-09/queue/queues/properties_set.go
@@ -53,6 +53,7 @@ func (client Client) SetServicePropertiesPreparer(ctx context.Context, accountNa
 		autorest.AsContentType("application/xml; charset=utf-8"),
 		autorest.AsPut(),
 		autorest.WithBaseURL(endpoints.GetQueueEndpoint(client.BaseURI, accountName)),
+		autorest.WithPath("/"),
 		autorest.WithQueryParameters(queryParameters),
 		autorest.WithXML(properties),
 		autorest.WithHeaders(headers))

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Number = "v0.3.1"
+const Number = "v0.3.2"


### PR DESCRIPTION
Same as #4 this bug only shows when using a SharedKey to authenticate, since the URL is different to what the Azure Storage API's are expecting