### PR TITLE
Explicitly setting the Content-Length header when content is provided

### DIFF
--- a/storage/2017-07-29/blob/blobs/append_block.go
+++ b/storage/2017-07-29/blob/blobs/append_block.go
@@ -122,6 +122,9 @@ func (client Client) AppendBlockPreparer(ctx context.Context, accountName, conta
 	if input.LeaseID != nil {
 		headers["x-ms-lease-id"] = *input.LeaseID
 	}
+	if input.Content != nil {
+		headers["Content-Length"] = int(len(*input.Content))
+	}
 
 	decorators := []autorest.PrepareDecorator{
 		autorest.AsPut(),

--- a/storage/2017-07-29/blob/blobs/put_block.go
+++ b/storage/2017-07-29/blob/blobs/put_block.go
@@ -80,7 +80,8 @@ func (client Client) PutBlockPreparer(ctx context.Context, accountName, containe
 	}
 
 	headers := map[string]interface{}{
-		"x-ms-version": APIVersion,
+		"x-ms-version":   APIVersion,
+		"Content-Length": int(len(input.Content)),
 	}
 
 	if input.ContentMD5 != nil {

--- a/storage/2017-07-29/blob/blobs/put_block_blob.go
+++ b/storage/2017-07-29/blob/blobs/put_block_blob.go
@@ -102,6 +102,9 @@ func (client Client) PutBlockBlobPreparer(ctx context.Context, accountName, cont
 	if input.LeaseID != nil {
 		headers["x-ms-lease-id"] = *input.LeaseID
 	}
+	if input.Content != nil {
+		headers["Content-Length"] = int(len(*input.Content))
+	}
 
 	headers = metadata.SetIntoHeaders(headers, input.MetaData)
 

--- a/storage/2017-07-29/blob/blobs/put_page_update.go
+++ b/storage/2017-07-29/blob/blobs/put_page_update.go
@@ -99,6 +99,7 @@ func (client Client) PutPageUpdatePreparer(ctx context.Context, accountName, con
 		"x-ms-version":    APIVersion,
 		"x-ms-page-write": "update",
 		"x-ms-range":      fmt.Sprintf("bytes=%d-%d", input.StartByte, input.EndByte),
+		"Content-Length":  int(len(input.Content)),
 	}
 
 	if input.LeaseID != nil {

--- a/storage/2017-07-29/file/files/range_put.go
+++ b/storage/2017-07-29/file/files/range_put.go
@@ -93,9 +93,10 @@ func (client Client) PutByteRangePreparer(ctx context.Context, accountName, shar
 	}
 
 	headers := map[string]interface{}{
-		"x-ms-version": APIVersion,
-		"x-ms-write":   "update",
-		"x-ms-range":   fmt.Sprintf("bytes=%d-%d", input.StartBytes, input.EndBytes-1),
+		"x-ms-version":   APIVersion,
+		"x-ms-write":     "update",
+		"x-ms-range":     fmt.Sprintf("bytes=%d-%d", input.StartBytes, input.EndBytes-1),
+		"Content-Length": int(len(input.Content)),
 	}
 
 	preparer := autorest.CreatePreparer(

--- a/storage/2018-03-28/blob/blobs/append_block.go
+++ b/storage/2018-03-28/blob/blobs/append_block.go
@@ -122,6 +122,9 @@ func (client Client) AppendBlockPreparer(ctx context.Context, accountName, conta
 	if input.LeaseID != nil {
 		headers["x-ms-lease-id"] = *input.LeaseID
 	}
+	if input.Content != nil {
+		headers["Content-Length"] = int(len(*input.Content))
+	}
 
 	decorators := []autorest.PrepareDecorator{
 		autorest.AsPut(),

--- a/storage/2018-03-28/blob/blobs/put_block.go
+++ b/storage/2018-03-28/blob/blobs/put_block.go
@@ -80,7 +80,8 @@ func (client Client) PutBlockPreparer(ctx context.Context, accountName, containe
 	}
 
 	headers := map[string]interface{}{
-		"x-ms-version": APIVersion,
+		"x-ms-version":   APIVersion,
+		"Content-Length": int(len(input.Content)),
 	}
 
 	if input.ContentMD5 != nil {

--- a/storage/2018-03-28/blob/blobs/put_block_blob.go
+++ b/storage/2018-03-28/blob/blobs/put_block_blob.go
@@ -102,6 +102,9 @@ func (client Client) PutBlockBlobPreparer(ctx context.Context, accountName, cont
 	if input.LeaseID != nil {
 		headers["x-ms-lease-id"] = *input.LeaseID
 	}
+	if input.Content != nil {
+		headers["Content-Length"] = int(len(*input.Content))
+	}
 
 	headers = metadata.SetIntoHeaders(headers, input.MetaData)
 

--- a/storage/2018-03-28/blob/blobs/put_page_update.go
+++ b/storage/2018-03-28/blob/blobs/put_page_update.go
@@ -99,6 +99,7 @@ func (client Client) PutPageUpdatePreparer(ctx context.Context, accountName, con
 		"x-ms-version":    APIVersion,
 		"x-ms-page-write": "update",
 		"x-ms-range":      fmt.Sprintf("bytes=%d-%d", input.StartByte, input.EndByte),
+		"Content-Length":  int(len(input.Content)),
 	}
 
 	if input.LeaseID != nil {

--- a/storage/2018-03-28/file/files/range_put.go
+++ b/storage/2018-03-28/file/files/range_put.go
@@ -93,9 +93,10 @@ func (client Client) PutByteRangePreparer(ctx context.Context, accountName, shar
 	}
 
 	headers := map[string]interface{}{
-		"x-ms-version": APIVersion,
-		"x-ms-write":   "update",
-		"x-ms-range":   fmt.Sprintf("bytes=%d-%d", input.StartBytes, input.EndBytes-1),
+		"x-ms-version":   APIVersion,
+		"x-ms-write":     "update",
+		"x-ms-range":     fmt.Sprintf("bytes=%d-%d", input.StartBytes, input.EndBytes-1),
+		"Content-Length": int(len(input.Content)),
 	}
 
 	preparer := autorest.CreatePreparer(

--- a/storage/2018-11-09/blob/blobs/append_block.go
+++ b/storage/2018-11-09/blob/blobs/append_block.go
@@ -122,6 +122,9 @@ func (client Client) AppendBlockPreparer(ctx context.Context, accountName, conta
 	if input.LeaseID != nil {
 		headers["x-ms-lease-id"] = *input.LeaseID
 	}
+	if input.Content != nil {
+		headers["Content-Length"] = int(len(*input.Content))
+	}
 
 	decorators := []autorest.PrepareDecorator{
 		autorest.AsPut(),

--- a/storage/2018-11-09/blob/blobs/put_block.go
+++ b/storage/2018-11-09/blob/blobs/put_block.go
@@ -80,7 +80,8 @@ func (client Client) PutBlockPreparer(ctx context.Context, accountName, containe
 	}
 
 	headers := map[string]interface{}{
-		"x-ms-version": APIVersion,
+		"x-ms-version":   APIVersion,
+		"Content-Length": int(len(input.Content)),
 	}
 
 	if input.ContentMD5 != nil {

--- a/storage/2018-11-09/blob/blobs/put_block_blob.go
+++ b/storage/2018-11-09/blob/blobs/put_block_blob.go
@@ -102,6 +102,9 @@ func (client Client) PutBlockBlobPreparer(ctx context.Context, accountName, cont
 	if input.LeaseID != nil {
 		headers["x-ms-lease-id"] = *input.LeaseID
 	}
+	if input.Content != nil {
+		headers["Content-Length"] = int(len(*input.Content))
+	}
 
 	headers = metadata.SetIntoHeaders(headers, input.MetaData)
 

--- a/storage/2018-11-09/blob/blobs/put_page_update.go
+++ b/storage/2018-11-09/blob/blobs/put_page_update.go
@@ -99,6 +99,7 @@ func (client Client) PutPageUpdatePreparer(ctx context.Context, accountName, con
 		"x-ms-version":    APIVersion,
 		"x-ms-page-write": "update",
 		"x-ms-range":      fmt.Sprintf("bytes=%d-%d", input.StartByte, input.EndByte),
+		"Content-Length":  int(len(input.Content)),
 	}
 
 	if input.LeaseID != nil {

--- a/storage/2018-11-09/file/files/range_put.go
+++ b/storage/2018-11-09/file/files/range_put.go
@@ -93,9 +93,10 @@ func (client Client) PutByteRangePreparer(ctx context.Context, accountName, shar
 	}
 
 	headers := map[string]interface{}{
-		"x-ms-version": APIVersion,
-		"x-ms-write":   "update",
-		"x-ms-range":   fmt.Sprintf("bytes=%d-%d", input.StartBytes, input.EndBytes-1),
+		"x-ms-version":   APIVersion,
+		"x-ms-write":     "update",
+		"x-ms-range":     fmt.Sprintf("bytes=%d-%d", input.StartBytes, input.EndBytes-1),
+		"Content-Length": int(len(input.Content)),
 	}
 
 	preparer := autorest.CreatePreparer(


### PR DESCRIPTION
Whilst this is inadvertently set via the `autorest.WithBytes` method
this PR forces this value to be set, so that this can be used for
building the SharedKey auth header