### PR TITLE
Support for DataLakeStorage Gen2 File Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ An alternative Azure Storage SDK for Go
 This repository is an alternative Azure Storage SDK for Go; which supports for:
 
 - The [Blob Storage APIs](https://docs.microsoft.com/en-us/rest/api/storageservices/blob-service-rest-api)
+- The [DataLake Gen2 APIs](https://docs.microsoft.com/en-us/rest/api/storageservices/data-lake-storage-gen2)
 - The [File Storage APIs](https://docs.microsoft.com/en-us/rest/api/storageservices/file-service-rest-api)
 - The [Queue Storage APIs](https://docs.microsoft.com/en-us/rest/api/storageservices/queue-service-rest-api)
 - The [Table Storage APIs](https://docs.microsoft.com/en-us/rest/api/storageservices/table-service-rest-api)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An alternative Azure Storage SDK for Go
 This repository is an alternative Azure Storage SDK for Go; which supports for:
 
 - The [Blob Storage APIs](https://docs.microsoft.com/en-us/rest/api/storageservices/blob-service-rest-api)
-- The [DataLake Gen2 APIs](https://docs.microsoft.com/en-us/rest/api/storageservices/data-lake-storage-gen2)
+- The [DataLakeStorage Gen2 APIs](https://docs.microsoft.com/en-us/rest/api/storageservices/data-lake-storage-gen2)
 - The [File Storage APIs](https://docs.microsoft.com/en-us/rest/api/storageservices/file-service-rest-api)
 - The [Queue Storage APIs](https://docs.microsoft.com/en-us/rest/api/storageservices/queue-service-rest-api)
 - The [Table Storage APIs](https://docs.microsoft.com/en-us/rest/api/storageservices/table-service-rest-api)
@@ -60,6 +60,8 @@ Depending on the API Version / API being used - different authentication mechani
 * A SharedKeyLite Authorizer (for Table Storage)
 
 Examples for all of these can be found below in [the Examples Directory](examples/).
+
+There's a [Pull Request open adding both a SharedKey and a SharedKeyLite authorizer to Azure/go-autorest](http://github.com/Azure/go-autorest/pull/416)  
 
 ## Running the Tests
 

--- a/storage/2018-03-28/README.md
+++ b/storage/2018-03-28/README.md
@@ -7,6 +7,10 @@ The following API's are supported by this SDK - more information about each SDK 
 - [Blobs API](blob/blobs)
 - [Containers API](blob/containers)
 
+## DataLakeStore Gen2
+
+- [FileSystems API](datalakestore/filesystems)
+
 ## File Storage
 
 - [Directories API](file/directories)

--- a/storage/2018-03-28/datalakestore/filesystems/README.md
+++ b/storage/2018-03-28/datalakestore/filesystems/README.md
@@ -1,0 +1,84 @@
+## Data Lake Storage Gen2 File Systems SDK for API version 2018-03-28
+
+This package allows you to interact with the Data Lake Storage Gen2 File Systems API
+
+### Supported Authorizers
+
+* Azure Active Directory (for the Resource Endpoint `https://storage.azure.com`)
+
+### Example Usage
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+    "time"
+	
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/adal"
+    "github.com/Azure/go-autorest/autorest/azure"
+    "github.com/hashicorp/go-azure-helpers/authentication"
+    "github.com/hashicorp/go-azure-helpers/sender"
+    "github.com/tombuildsstuff/giovanni/storage/2018-03-28/datalakestore/filesystems"
+)
+
+func Example() error {
+	accountName := "storageaccount1"
+    fileSystemName := "filesystem1"
+
+    builder := &authentication.Builder{
+        SubscriptionID: os.Getenv("ARM_SUBSCRIPTION_ID"),
+        ClientID:       os.Getenv("ARM_CLIENT_ID"),
+        ClientSecret:   os.Getenv("ARM_CLIENT_SECRET"),
+        TenantID:       os.Getenv("ARM_TENANT_ID"),
+        Environment:    os.Getenv("ARM_ENVIRONMENT"),
+
+        // Feature Toggles
+        SupportsClientSecretAuth: true,
+    }
+
+    c, err := builder.Build()
+    if err != nil {
+        return fmt.Errorf("Error building AzureRM Client: %s", err)
+    }
+
+    env, err := authentication.DetermineEnvironment(c.Environment)
+    if err != nil {
+        return err
+    }
+
+    oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, c.TenantID)
+	if err != nil {
+		return err
+	}
+
+	// OAuthConfigForTenant returns a pointer, which can be nil.
+	if oauthConfig == nil {
+		return fmt.Errorf("Unable to configure OAuthConfig for tenant %s", c.TenantID)
+	}
+
+    sender := sender.BuildSender("AzureRM")
+    ctx := context.Background()
+
+    storageAuth, err := config.GetAuthorizationToken(sender, oauthConfig, "https://storage.azure.com/")
+	if err != nil {
+		return fmt.Errorf("Error retrieving Authorization Token")
+	}
+
+   
+    fileSystemsClient := filesystems.NewWithEnvironment(env)
+	fileSystemsClient.Client.Authorizer = storageAuth
+
+	input := filesystems.CreateInput{
+		Properties: map[string]string{},
+	}
+	if _, err = fileSystemsClient.Create(ctx, accountName, fileSystemName, input); err != nil {
+		return fmt.Errorf("Error creating: %s", err)
+	}
+	
+    return nil 
+}
+```

--- a/storage/2018-03-28/datalakestore/filesystems/client.go
+++ b/storage/2018-03-28/datalakestore/filesystems/client.go
@@ -1,0 +1,25 @@
+package filesystems
+
+import (
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Client is the base client for Data Lake Storage FileSystem
+type Client struct {
+	autorest.Client
+	BaseURI string
+}
+
+// New creates an instance of the Data Lake Storage FileSystem client.
+func New() Client {
+	return NewWithEnvironment(azure.PublicCloud)
+}
+
+// NewWithEnvironment creates an instance of the Data Lake Storage FileSystem client.
+func NewWithEnvironment(environment azure.Environment) Client {
+	return Client{
+		Client:  autorest.NewClientWithUserAgent(UserAgent()),
+		BaseURI: environment.StorageEndpointSuffix,
+	}
+}

--- a/storage/2018-03-28/datalakestore/filesystems/create.go
+++ b/storage/2018-03-28/datalakestore/filesystems/create.go
@@ -1,0 +1,94 @@
+package filesystems
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+type CreateInput struct {
+	// A map of base64-encoded strings to store as user-defined properties with the File System
+	// Note that items may only contain ASCII characters in the ISO-8859-1 character set.
+	// This automatically gets converted to a comma-separated list of name and
+	// value pairs before sending to the API
+	Properties map[string]string
+}
+
+// Create creates a Data Lake Store Gen2 FileSystem within a Storage Account
+func (client Client) Create(ctx context.Context, accountName string, fileSystemName string, input CreateInput) (result autorest.Response, err error) {
+	if accountName == "" {
+		return result, validation.NewError("datalakestore.Client", "Create", "`accountName` cannot be an empty string.")
+	}
+	if fileSystemName == "" {
+		return result, validation.NewError("datalakestore.Client", "Create", "`fileSystemName` cannot be an empty string.")
+	}
+
+	req, err := client.CreatePreparer(ctx, accountName, fileSystemName, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "Create", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.CreateSender(req)
+	if err != nil {
+		result = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "Create", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.CreateResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "Create", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// CreatePreparer prepares the Create request.
+func (client Client) CreatePreparer(ctx context.Context, accountName string, fileSystemName string, input CreateInput) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"fileSystemName": autorest.Encode("path", fileSystemName),
+	}
+
+	queryParameters := map[string]interface{}{
+		"resource": autorest.Encode("query", "filesystem"),
+	}
+
+	headers := map[string]interface{}{
+		"x-ms-properties": buildProperties(input.Properties),
+		"x-ms-version":    APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsPut(),
+		autorest.WithBaseURL(endpoints.GetDataLakeStoreEndpoint(client.BaseURI, accountName)),
+		autorest.WithPathParameters("/{fileSystemName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters),
+		autorest.WithHeaders(headers))
+
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// CreateSender sends the Create request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) CreateSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// CreateResponder handles the response to the Create request. The method always
+// closes the http.Response Body.
+func (client Client) CreateResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusCreated),
+		autorest.ByClosing())
+	result = autorest.Response{Response: resp}
+
+	return
+}

--- a/storage/2018-03-28/datalakestore/filesystems/create_test.go
+++ b/storage/2018-03-28/datalakestore/filesystems/create_test.go
@@ -1,0 +1,53 @@
+package filesystems
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/storage/mgmt/storage"
+	"github.com/tombuildsstuff/giovanni/testhelpers"
+)
+
+func TestCreateHasNoTagsByDefault(t *testing.T) {
+	client, err := testhelpers.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.TODO()
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	fileSystemName := fmt.Sprintf("acctestfs-%s", testhelpers.RandomString())
+
+	if _, err = client.BuildTestResources(ctx, resourceGroup, accountName, storage.BlobStorage); err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	fileSystemsClient := NewWithEnvironment(client.Environment)
+	fileSystemsClient.Client = client.PrepareWithStorageResourceManagerAuth(fileSystemsClient.Client)
+
+	t.Logf("[DEBUG] Creating an empty File System..")
+	input := CreateInput{
+		Properties: map[string]string{},
+	}
+	if _, err = fileSystemsClient.Create(ctx, accountName, fileSystemName, input); err != nil {
+		t.Fatal(fmt.Errorf("Error creating: %s", err))
+	}
+
+	t.Logf("[DEBUG] Retrieving the Properties..")
+	props, err := fileSystemsClient.GetProperties(ctx, accountName, fileSystemName)
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error getting properties: %s", err))
+	}
+
+	if len(props.Properties) != 0 {
+		t.Fatalf("Expected 0 properties by default but got %d", len(props.Properties))
+	}
+
+	t.Logf("[DEBUG] Deleting File System..")
+	if _, err := fileSystemsClient.Delete(ctx, accountName, fileSystemName); err != nil {
+		t.Fatalf("Error deleting: %s", err)
+	}
+}

--- a/storage/2018-03-28/datalakestore/filesystems/delete.go
+++ b/storage/2018-03-28/datalakestore/filesystems/delete.go
@@ -1,0 +1,85 @@
+package filesystems
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+// Delete deletes a Data Lake Store Gen2 FileSystem within a Storage Account
+func (client Client) Delete(ctx context.Context, accountName string, fileSystemName string) (result autorest.Response, err error) {
+	if accountName == "" {
+		return result, validation.NewError("datalakestore.Client", "Delete", "`accountName` cannot be an empty string.")
+	}
+	if fileSystemName == "" {
+		return result, validation.NewError("datalakestore.Client", "Delete", "`fileSystemName` cannot be an empty string.")
+	}
+
+	req, err := client.DeletePreparer(ctx, accountName, fileSystemName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.DeleteSender(req)
+	if err != nil {
+		result = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "Delete", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.DeleteResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "Delete", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// DeletePreparer prepares the Delete request.
+func (client Client) DeletePreparer(ctx context.Context, accountName string, fileSystemName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"fileSystemName": autorest.Encode("path", fileSystemName),
+	}
+
+	queryParameters := map[string]interface{}{
+		"resource": autorest.Encode("query", "filesystem"),
+	}
+
+	headers := map[string]interface{}{
+		"x-ms-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsDelete(),
+		autorest.WithBaseURL(endpoints.GetDataLakeStoreEndpoint(client.BaseURI, accountName)),
+		autorest.WithPathParameters("/{fileSystemName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters),
+		autorest.WithHeaders(headers))
+
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// DeleteSender sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) DeleteSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// DeleteResponder handles the response to the Delete request. The method always
+// closes the http.Response Body.
+func (client Client) DeleteResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusAccepted),
+		autorest.ByClosing())
+	result = autorest.Response{Response: resp}
+
+	return
+}

--- a/storage/2018-03-28/datalakestore/filesystems/helpers.go
+++ b/storage/2018-03-28/datalakestore/filesystems/helpers.go
@@ -1,0 +1,40 @@
+package filesystems
+
+import (
+	"fmt"
+	"strings"
+)
+
+func buildProperties(input map[string]string) string {
+	// properties has to be a comma-separated key-value pair
+	properties := make([]string, 0)
+
+	for k, v := range input {
+		properties = append(properties, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return strings.Join(properties, ",")
+}
+
+func parseProperties(input string) (*map[string]string, error) {
+	properties := make(map[string]string)
+	if input == "" {
+		return &properties, nil
+	}
+
+	// properties is a comma-separated list of key-value pairs
+	splitProperties := strings.Split(input, ",")
+	for _, propertyRaw := range splitProperties {
+		// because these are base64-encoded they're likely to end in at least one =
+		// as such we can't string split on that -_-
+		position := strings.Index(propertyRaw, "=")
+		if position < 0 {
+			return nil, fmt.Errorf("Expected there to be an equals in the key value pair: %q", propertyRaw)
+		}
+
+		key := propertyRaw[0:position]
+		value := propertyRaw[position+1:]
+		properties[key] = value
+	}
+	return &properties, nil
+}

--- a/storage/2018-03-28/datalakestore/filesystems/helpers_test.go
+++ b/storage/2018-03-28/datalakestore/filesystems/helpers_test.go
@@ -1,0 +1,76 @@
+package filesystems
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseProperties(t *testing.T) {
+	testData := []struct {
+		name        string
+		input       string
+		expected    map[string]string
+		expectError bool
+	}{
+		{
+			name:        "no items",
+			input:       "",
+			expected:    map[string]string{},
+			expectError: false,
+		},
+		{
+			name:        "invalid item",
+			input:       "hello",
+			expectError: true,
+		},
+		{
+			name:  "single item",
+			input: "hello=world",
+			expected: map[string]string{
+				"hello": "world",
+			},
+		},
+		{
+			name:  "single-item-base64",
+			input: "hello=aGVsbG8=",
+			expected: map[string]string{
+				"hello": "aGVsbG8=",
+			},
+			expectError: false,
+		},
+		{
+			name:  "single-item-base64-multipleequals",
+			input: "hello=d29uZGVybGFuZA==",
+			expected: map[string]string{
+				"hello": "d29uZGVybGFuZA==",
+			},
+			expectError: false,
+		},
+		{
+			name:  "multiple-items-base64",
+			input: "hello=d29uZGVybGFuZA==,private=ZXll",
+
+			expected: map[string]string{
+				"hello":   "d29uZGVybGFuZA==",
+				"private": "ZXll",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, testCase := range testData {
+		t.Logf("[DEBUG] Test %q", testCase.name)
+
+		actual, err := parseProperties(testCase.input)
+		if err != nil {
+			if testCase.expectError {
+				continue
+			}
+
+			t.Fatalf("[DEBUG] Didn't expect an error but got %s", err)
+		}
+		if !reflect.DeepEqual(testCase.expected, *actual) {
+			t.Fatalf("Expected %+v but got %+v", testCase.expected, *actual)
+		}
+	}
+}

--- a/storage/2018-03-28/datalakestore/filesystems/lifecycle_test.go
+++ b/storage/2018-03-28/datalakestore/filesystems/lifecycle_test.go
@@ -1,0 +1,83 @@
+package filesystems
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/storage/mgmt/storage"
+	"github.com/tombuildsstuff/giovanni/testhelpers"
+)
+
+func TestLifecycle(t *testing.T) {
+	client, err := testhelpers.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.TODO()
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	fileSystemName := fmt.Sprintf("acctestfs-%s", testhelpers.RandomString())
+
+	if _, err = client.BuildTestResources(ctx, resourceGroup, accountName, storage.BlobStorage); err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+	fileSystemsClient := NewWithEnvironment(client.Environment)
+	fileSystemsClient.Client = client.PrepareWithStorageResourceManagerAuth(fileSystemsClient.Client)
+
+	t.Logf("[DEBUG] Creating an empty File System..")
+	input := CreateInput{
+		Properties: map[string]string{
+			"hello": "aGVsbG8=",
+		},
+	}
+	if _, err = fileSystemsClient.Create(ctx, accountName, fileSystemName, input); err != nil {
+		t.Fatal(fmt.Errorf("Error creating: %s", err))
+	}
+
+	t.Logf("[DEBUG] Retrieving the Properties..")
+	props, err := fileSystemsClient.GetProperties(ctx, accountName, fileSystemName)
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error getting properties: %s", err))
+	}
+
+	if len(props.Properties) != 1 {
+		t.Fatalf("Expected 1 properties by default but got %d", len(props.Properties))
+	}
+	if props.Properties["hello"] != "aGVsbG8=" {
+		t.Fatalf("Expected `hello` to be `aGVsbG8=` but got %q", props.Properties["hello"])
+	}
+
+	t.Logf("[DEBUG] Updating the properties..")
+	setInput := SetPropertiesInput{
+		Properties: map[string]string{
+			"hello":   "d29uZGVybGFuZA==",
+			"private": "ZXll",
+		},
+	}
+	if _, err := fileSystemsClient.SetProperties(ctx, accountName, fileSystemName, setInput); err != nil {
+		t.Fatalf("Error setting properties: %s", err)
+	}
+
+	t.Logf("[DEBUG] Re-Retrieving the Properties..")
+	props, err = fileSystemsClient.GetProperties(ctx, accountName, fileSystemName)
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error getting properties: %s", err))
+	}
+	if len(props.Properties) != 2 {
+		t.Fatalf("Expected 2 properties by default but got %d", len(props.Properties))
+	}
+	if props.Properties["hello"] != "d29uZGVybGFuZA==" {
+		t.Fatalf("Expected `hello` to be `d29uZGVybGFuZA==` but got %q", props.Properties["hello"])
+	}
+	if props.Properties["private"] != "ZXll" {
+		t.Fatalf("Expected `private` to be `ZXll` but got %q", props.Properties["private"])
+	}
+
+	t.Logf("[DEBUG] Deleting File System..")
+	if _, err := fileSystemsClient.Delete(ctx, accountName, fileSystemName); err != nil {
+		t.Fatalf("Error deleting: %s", err)
+	}
+}

--- a/storage/2018-03-28/datalakestore/filesystems/properties_get.go
+++ b/storage/2018-03-28/datalakestore/filesystems/properties_get.go
@@ -1,0 +1,112 @@
+package filesystems
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+type GetPropertiesResponse struct {
+	autorest.Response
+
+	// A map of base64-encoded strings to store as user-defined properties with the File System
+	// Note that items may only contain ASCII characters in the ISO-8859-1 character set.
+	// This automatically gets converted to a comma-separated list of name and
+	// value pairs before sending to the API
+	Properties map[string]string
+
+	// Is Hierarchical Namespace Enabled?
+	NamespaceEnabled bool
+}
+
+// GetProperties gets the properties for a Data Lake Store Gen2 FileSystem within a Storage Account
+func (client Client) GetProperties(ctx context.Context, accountName string, fileSystemName string) (result GetPropertiesResponse, err error) {
+	if accountName == "" {
+		return result, validation.NewError("datalakestore.Client", "GetProperties", "`accountName` cannot be an empty string.")
+	}
+	if fileSystemName == "" {
+		return result, validation.NewError("datalakestore.Client", "GetProperties", "`fileSystemName` cannot be an empty string.")
+	}
+
+	req, err := client.GetPropertiesPreparer(ctx, accountName, fileSystemName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "GetProperties", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.GetPropertiesSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "GetProperties", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.GetPropertiesResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "GetProperties", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// GetPropertiesPreparer prepares the GetProperties request.
+func (client Client) GetPropertiesPreparer(ctx context.Context, accountName string, fileSystemName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"fileSystemName": autorest.Encode("path", fileSystemName),
+	}
+
+	queryParameters := map[string]interface{}{
+		"resource": autorest.Encode("query", "filesystem"),
+	}
+
+	headers := map[string]interface{}{
+		"x-ms-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsHead(),
+		autorest.WithBaseURL(endpoints.GetDataLakeStoreEndpoint(client.BaseURI, accountName)),
+		autorest.WithPathParameters("/{fileSystemName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters),
+		autorest.WithHeaders(headers))
+
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// GetPropertiesSender sends the GetProperties request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) GetPropertiesSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// GetPropertiesResponder handles the response to the GetProperties request. The method always
+// closes the http.Response Body.
+func (client Client) GetPropertiesResponder(resp *http.Response) (result GetPropertiesResponse, err error) {
+	if resp != nil && resp.Header != nil {
+
+		propertiesRaw := resp.Header.Get("x-ms-properties")
+		var properties *map[string]string
+		properties, err = parseProperties(propertiesRaw)
+		if err != nil {
+			return
+		}
+
+		result.Properties = *properties
+		result.NamespaceEnabled = strings.EqualFold(resp.Header.Get("x-ms-namespace-enabled"), "tru")
+	}
+
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+
+	return
+}

--- a/storage/2018-03-28/datalakestore/filesystems/properties_set.go
+++ b/storage/2018-03-28/datalakestore/filesystems/properties_set.go
@@ -1,0 +1,109 @@
+package filesystems
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+type SetPropertiesInput struct {
+	// A map of base64-encoded strings to store as user-defined properties with the File System
+	// Note that items may only contain ASCII characters in the ISO-8859-1 character set.
+	// This automatically gets converted to a comma-separated list of name and
+	// value pairs before sending to the API
+	Properties map[string]string
+
+	// Optional - A date and time value.
+	// Specify this header to perform the operation only if the resource has been modified since the specified date and time.
+	IfModifiedSince *string
+
+	// Optional - A date and time value.
+	// Specify this header to perform the operation only if the resource has not been modified since the specified date and time.
+	IfUnmodifiedSince *string
+}
+
+// SetProperties sets the Properties for a Data Lake Store Gen2 FileSystem within a Storage Account
+func (client Client) SetProperties(ctx context.Context, accountName string, fileSystemName string, input SetPropertiesInput) (result autorest.Response, err error) {
+	if accountName == "" {
+		return result, validation.NewError("datalakestore.Client", "SetProperties", "`accountName` cannot be an empty string.")
+	}
+	if fileSystemName == "" {
+		return result, validation.NewError("datalakestore.Client", "SetProperties", "`fileSystemName` cannot be an empty string.")
+	}
+
+	req, err := client.SetPropertiesPreparer(ctx, accountName, fileSystemName, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "SetProperties", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.SetPropertiesSender(req)
+	if err != nil {
+		result = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "SetProperties", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.SetPropertiesResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "SetProperties", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// SetPropertiesPreparer prepares the SetProperties request.
+func (client Client) SetPropertiesPreparer(ctx context.Context, accountName string, fileSystemName string, input SetPropertiesInput) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"fileSystemName": autorest.Encode("path", fileSystemName),
+	}
+
+	queryParameters := map[string]interface{}{
+		"resource": autorest.Encode("query", "filesystem"),
+	}
+
+	headers := map[string]interface{}{
+		"x-ms-properties": buildProperties(input.Properties),
+		"x-ms-version":    APIVersion,
+	}
+
+	if input.IfModifiedSince != nil {
+		headers["If-Modified-Since"] = *input.IfModifiedSince
+	}
+	if input.IfUnmodifiedSince != nil {
+		headers["If-Unmodified-Since"] = *input.IfUnmodifiedSince
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsPatch(),
+		autorest.WithBaseURL(endpoints.GetDataLakeStoreEndpoint(client.BaseURI, accountName)),
+		autorest.WithPathParameters("/{fileSystemName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters),
+		autorest.WithHeaders(headers))
+
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// SetPropertiesSender sends the SetProperties request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) SetPropertiesSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// SetPropertiesResponder handles the response to the SetProperties request. The method always
+// closes the http.Response Body.
+func (client Client) SetPropertiesResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+	result = autorest.Response{Response: resp}
+
+	return
+}

--- a/storage/2018-03-28/datalakestore/filesystems/resource_id.go
+++ b/storage/2018-03-28/datalakestore/filesystems/resource_id.go
@@ -1,0 +1,46 @@
+package filesystems
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+// GetResourceID returns the Resource ID for the given Data Lake Storage FileSystem
+// This can be useful when, for example, you're using this as a unique identifier
+func (client Client) GetResourceID(accountName, shareName string) string {
+	domain := endpoints.GetDataLakeStoreEndpoint(client.BaseURI, accountName)
+	return fmt.Sprintf("%s/%s", domain, shareName)
+}
+
+type ResourceID struct {
+	AccountName   string
+	DirectoryName string
+}
+
+// ParseResourceID parses the specified Resource ID and returns an object
+// which can be used to interact with the Data Lake Storage FileSystem API's
+func ParseResourceID(id string) (*ResourceID, error) {
+	// example: https://foo.dfs.core.windows.net/Bar
+	if id == "" {
+		return nil, fmt.Errorf("`id` was empty")
+	}
+
+	uri, err := url.Parse(id)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing ID as a URL: %s", err)
+	}
+
+	accountName, err := endpoints.GetAccountNameFromEndpoint(uri.Host)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing Account Name: %s", err)
+	}
+
+	directoryName := strings.TrimPrefix(uri.Path, "/")
+	return &ResourceID{
+		AccountName:   *accountName,
+		DirectoryName: directoryName,
+	}, nil
+}

--- a/storage/2018-03-28/datalakestore/filesystems/resource_id_test.go
+++ b/storage/2018-03-28/datalakestore/filesystems/resource_id_test.go
@@ -1,0 +1,78 @@
+package filesystems
+
+import (
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+func TestGetResourceID(t *testing.T) {
+	testData := []struct {
+		Environment azure.Environment
+		Expected    string
+	}{
+		{
+			Environment: azure.ChinaCloud,
+			Expected:    "https://account1.dfs.core.chinacloudapi.cn/directory1",
+		},
+		{
+			Environment: azure.GermanCloud,
+			Expected:    "https://account1.dfs.core.cloudapi.de/directory1",
+		},
+		{
+			Environment: azure.PublicCloud,
+			Expected:    "https://account1.dfs.core.windows.net/directory1",
+		},
+		{
+			Environment: azure.USGovernmentCloud,
+			Expected:    "https://account1.dfs.core.usgovcloudapi.net/directory1",
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
+		c := NewWithEnvironment(v.Environment)
+		actual := c.GetResourceID("account1", "directory1")
+		if actual != v.Expected {
+			t.Fatalf("Expected the Resource ID to be %q but got %q", v.Expected, actual)
+		}
+	}
+}
+
+func TestParseResourceID(t *testing.T) {
+	testData := []struct {
+		Environment azure.Environment
+		Input       string
+	}{
+		{
+			Environment: azure.ChinaCloud,
+			Input:       "https://account1.dfs.core.chinacloudapi.cn/directory1",
+		},
+		{
+			Environment: azure.GermanCloud,
+			Input:       "https://account1.dfs.core.cloudapi.de/directory1",
+		},
+		{
+			Environment: azure.PublicCloud,
+			Input:       "https://account1.dfs.core.windows.net/directory1",
+		},
+		{
+			Environment: azure.USGovernmentCloud,
+			Input:       "https://account1.dfs.core.usgovcloudapi.net/directory1",
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
+		actual, err := ParseResourceID(v.Input)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if actual.AccountName != "account1" {
+			t.Fatalf("Expected the account name to be `account1` but got %q", actual.AccountName)
+		}
+
+		if actual.DirectoryName != "directory1" {
+			t.Fatalf("Expected the directory name to be `directory1` but got %q", actual.DirectoryName)
+		}
+	}
+}

--- a/storage/2018-03-28/datalakestore/filesystems/version.go
+++ b/storage/2018-03-28/datalakestore/filesystems/version.go
@@ -1,0 +1,14 @@
+package filesystems
+
+import (
+	"fmt"
+
+	"github.com/tombuildsstuff/giovanni/version"
+)
+
+// APIVersion is the version of the API used for all Storage API Operations
+const APIVersion = "2018-03-28"
+
+func UserAgent() string {
+	return fmt.Sprintf("tombuildsstuff/giovanni/%s storage/%s", version.Number, APIVersion)
+}

--- a/storage/2018-11-09/README.md
+++ b/storage/2018-11-09/README.md
@@ -7,6 +7,10 @@ The following API's are supported by this SDK - more information about each SDK 
 - [Blobs API](blob/blobs)
 - [Containers API](blob/containers)
 
+## DataLakeStore Gen2
+
+- [FileSystems API](datalakestore/filesystems)
+
 ## File Storage
 
 - [Directories API](file/directories)

--- a/storage/2018-11-09/datalakestore/filesystems/README.md
+++ b/storage/2018-11-09/datalakestore/filesystems/README.md
@@ -1,0 +1,84 @@
+## Data Lake Storage Gen2 File Systems SDK for API version 2018-11-09
+
+This package allows you to interact with the Data Lake Storage Gen2 File Systems API
+
+### Supported Authorizers
+
+* Azure Active Directory (for the Resource Endpoint `https://storage.azure.com`)
+
+### Example Usage
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+    "time"
+	
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/adal"
+    "github.com/Azure/go-autorest/autorest/azure"
+    "github.com/hashicorp/go-azure-helpers/authentication"
+    "github.com/hashicorp/go-azure-helpers/sender"
+    "github.com/tombuildsstuff/giovanni/storage/2018-11-09/datalakestore/filesystems"
+)
+
+func Example() error {
+	accountName := "storageaccount1"
+    fileSystemName := "filesystem1"
+
+    builder := &authentication.Builder{
+        SubscriptionID: os.Getenv("ARM_SUBSCRIPTION_ID"),
+        ClientID:       os.Getenv("ARM_CLIENT_ID"),
+        ClientSecret:   os.Getenv("ARM_CLIENT_SECRET"),
+        TenantID:       os.Getenv("ARM_TENANT_ID"),
+        Environment:    os.Getenv("ARM_ENVIRONMENT"),
+
+        // Feature Toggles
+        SupportsClientSecretAuth: true,
+    }
+
+    c, err := builder.Build()
+    if err != nil {
+        return fmt.Errorf("Error building AzureRM Client: %s", err)
+    }
+
+    env, err := authentication.DetermineEnvironment(c.Environment)
+    if err != nil {
+        return err
+    }
+
+    oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, c.TenantID)
+	if err != nil {
+		return err
+	}
+
+	// OAuthConfigForTenant returns a pointer, which can be nil.
+	if oauthConfig == nil {
+		return fmt.Errorf("Unable to configure OAuthConfig for tenant %s", c.TenantID)
+	}
+
+    sender := sender.BuildSender("AzureRM")
+    ctx := context.Background()
+
+    storageAuth, err := config.GetAuthorizationToken(sender, oauthConfig, "https://storage.azure.com/")
+	if err != nil {
+		return fmt.Errorf("Error retrieving Authorization Token")
+	}
+
+   
+    fileSystemsClient := filesystems.NewWithEnvironment(env)
+	fileSystemsClient.Client.Authorizer = storageAuth
+
+	input := filesystems.CreateInput{
+		Properties: map[string]string{},
+	}
+	if _, err = fileSystemsClient.Create(ctx, accountName, fileSystemName, input); err != nil {
+		return fmt.Errorf("Error creating: %s", err)
+	}
+	
+    return nil 
+}
+```

--- a/storage/2018-11-09/datalakestore/filesystems/client.go
+++ b/storage/2018-11-09/datalakestore/filesystems/client.go
@@ -1,0 +1,25 @@
+package filesystems
+
+import (
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Client is the base client for Data Lake Storage FileSystem
+type Client struct {
+	autorest.Client
+	BaseURI string
+}
+
+// New creates an instance of the Data Lake Storage FileSystem client.
+func New() Client {
+	return NewWithEnvironment(azure.PublicCloud)
+}
+
+// NewWithEnvironment creates an instance of the Data Lake Storage FileSystem client.
+func NewWithEnvironment(environment azure.Environment) Client {
+	return Client{
+		Client:  autorest.NewClientWithUserAgent(UserAgent()),
+		BaseURI: environment.StorageEndpointSuffix,
+	}
+}

--- a/storage/2018-11-09/datalakestore/filesystems/create.go
+++ b/storage/2018-11-09/datalakestore/filesystems/create.go
@@ -1,0 +1,94 @@
+package filesystems
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+type CreateInput struct {
+	// A map of base64-encoded strings to store as user-defined properties with the File System
+	// Note that items may only contain ASCII characters in the ISO-8859-1 character set.
+	// This automatically gets converted to a comma-separated list of name and
+	// value pairs before sending to the API
+	Properties map[string]string
+}
+
+// Create creates a Data Lake Store Gen2 FileSystem within a Storage Account
+func (client Client) Create(ctx context.Context, accountName string, fileSystemName string, input CreateInput) (result autorest.Response, err error) {
+	if accountName == "" {
+		return result, validation.NewError("datalakestore.Client", "Create", "`accountName` cannot be an empty string.")
+	}
+	if fileSystemName == "" {
+		return result, validation.NewError("datalakestore.Client", "Create", "`fileSystemName` cannot be an empty string.")
+	}
+
+	req, err := client.CreatePreparer(ctx, accountName, fileSystemName, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "Create", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.CreateSender(req)
+	if err != nil {
+		result = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "Create", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.CreateResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "Create", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// CreatePreparer prepares the Create request.
+func (client Client) CreatePreparer(ctx context.Context, accountName string, fileSystemName string, input CreateInput) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"fileSystemName": autorest.Encode("path", fileSystemName),
+	}
+
+	queryParameters := map[string]interface{}{
+		"resource": autorest.Encode("query", "filesystem"),
+	}
+
+	headers := map[string]interface{}{
+		"x-ms-properties": buildProperties(input.Properties),
+		"x-ms-version":    APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsPut(),
+		autorest.WithBaseURL(endpoints.GetDataLakeStoreEndpoint(client.BaseURI, accountName)),
+		autorest.WithPathParameters("/{fileSystemName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters),
+		autorest.WithHeaders(headers))
+
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// CreateSender sends the Create request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) CreateSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// CreateResponder handles the response to the Create request. The method always
+// closes the http.Response Body.
+func (client Client) CreateResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusCreated),
+		autorest.ByClosing())
+	result = autorest.Response{Response: resp}
+
+	return
+}

--- a/storage/2018-11-09/datalakestore/filesystems/create_test.go
+++ b/storage/2018-11-09/datalakestore/filesystems/create_test.go
@@ -1,0 +1,53 @@
+package filesystems
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/storage/mgmt/storage"
+	"github.com/tombuildsstuff/giovanni/testhelpers"
+)
+
+func TestCreateHasNoTagsByDefault(t *testing.T) {
+	client, err := testhelpers.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.TODO()
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	fileSystemName := fmt.Sprintf("acctestfs-%s", testhelpers.RandomString())
+
+	if _, err = client.BuildTestResources(ctx, resourceGroup, accountName, storage.BlobStorage); err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	fileSystemsClient := NewWithEnvironment(client.Environment)
+	fileSystemsClient.Client = client.PrepareWithStorageResourceManagerAuth(fileSystemsClient.Client)
+
+	t.Logf("[DEBUG] Creating an empty File System..")
+	input := CreateInput{
+		Properties: map[string]string{},
+	}
+	if _, err = fileSystemsClient.Create(ctx, accountName, fileSystemName, input); err != nil {
+		t.Fatal(fmt.Errorf("Error creating: %s", err))
+	}
+
+	t.Logf("[DEBUG] Retrieving the Properties..")
+	props, err := fileSystemsClient.GetProperties(ctx, accountName, fileSystemName)
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error getting properties: %s", err))
+	}
+
+	if len(props.Properties) != 0 {
+		t.Fatalf("Expected 0 properties by default but got %d", len(props.Properties))
+	}
+
+	t.Logf("[DEBUG] Deleting File System..")
+	if _, err := fileSystemsClient.Delete(ctx, accountName, fileSystemName); err != nil {
+		t.Fatalf("Error deleting: %s", err)
+	}
+}

--- a/storage/2018-11-09/datalakestore/filesystems/delete.go
+++ b/storage/2018-11-09/datalakestore/filesystems/delete.go
@@ -1,0 +1,85 @@
+package filesystems
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+// Delete deletes a Data Lake Store Gen2 FileSystem within a Storage Account
+func (client Client) Delete(ctx context.Context, accountName string, fileSystemName string) (result autorest.Response, err error) {
+	if accountName == "" {
+		return result, validation.NewError("datalakestore.Client", "Delete", "`accountName` cannot be an empty string.")
+	}
+	if fileSystemName == "" {
+		return result, validation.NewError("datalakestore.Client", "Delete", "`fileSystemName` cannot be an empty string.")
+	}
+
+	req, err := client.DeletePreparer(ctx, accountName, fileSystemName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.DeleteSender(req)
+	if err != nil {
+		result = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "Delete", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.DeleteResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "Delete", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// DeletePreparer prepares the Delete request.
+func (client Client) DeletePreparer(ctx context.Context, accountName string, fileSystemName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"fileSystemName": autorest.Encode("path", fileSystemName),
+	}
+
+	queryParameters := map[string]interface{}{
+		"resource": autorest.Encode("query", "filesystem"),
+	}
+
+	headers := map[string]interface{}{
+		"x-ms-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsDelete(),
+		autorest.WithBaseURL(endpoints.GetDataLakeStoreEndpoint(client.BaseURI, accountName)),
+		autorest.WithPathParameters("/{fileSystemName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters),
+		autorest.WithHeaders(headers))
+
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// DeleteSender sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) DeleteSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// DeleteResponder handles the response to the Delete request. The method always
+// closes the http.Response Body.
+func (client Client) DeleteResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusAccepted),
+		autorest.ByClosing())
+	result = autorest.Response{Response: resp}
+
+	return
+}

--- a/storage/2018-11-09/datalakestore/filesystems/helpers.go
+++ b/storage/2018-11-09/datalakestore/filesystems/helpers.go
@@ -1,0 +1,40 @@
+package filesystems
+
+import (
+	"fmt"
+	"strings"
+)
+
+func buildProperties(input map[string]string) string {
+	// properties has to be a comma-separated key-value pair
+	properties := make([]string, 0)
+
+	for k, v := range input {
+		properties = append(properties, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return strings.Join(properties, ",")
+}
+
+func parseProperties(input string) (*map[string]string, error) {
+	properties := make(map[string]string)
+	if input == "" {
+		return &properties, nil
+	}
+
+	// properties is a comma-separated list of key-value pairs
+	splitProperties := strings.Split(input, ",")
+	for _, propertyRaw := range splitProperties {
+		// because these are base64-encoded they're likely to end in at least one =
+		// as such we can't string split on that -_-
+		position := strings.Index(propertyRaw, "=")
+		if position < 0 {
+			return nil, fmt.Errorf("Expected there to be an equals in the key value pair: %q", propertyRaw)
+		}
+
+		key := propertyRaw[0:position]
+		value := propertyRaw[position+1:]
+		properties[key] = value
+	}
+	return &properties, nil
+}

--- a/storage/2018-11-09/datalakestore/filesystems/helpers_test.go
+++ b/storage/2018-11-09/datalakestore/filesystems/helpers_test.go
@@ -1,0 +1,76 @@
+package filesystems
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseProperties(t *testing.T) {
+	testData := []struct {
+		name        string
+		input       string
+		expected    map[string]string
+		expectError bool
+	}{
+		{
+			name:        "no items",
+			input:       "",
+			expected:    map[string]string{},
+			expectError: false,
+		},
+		{
+			name:        "invalid item",
+			input:       "hello",
+			expectError: true,
+		},
+		{
+			name:  "single item",
+			input: "hello=world",
+			expected: map[string]string{
+				"hello": "world",
+			},
+		},
+		{
+			name:  "single-item-base64",
+			input: "hello=aGVsbG8=",
+			expected: map[string]string{
+				"hello": "aGVsbG8=",
+			},
+			expectError: false,
+		},
+		{
+			name:  "single-item-base64-multipleequals",
+			input: "hello=d29uZGVybGFuZA==",
+			expected: map[string]string{
+				"hello": "d29uZGVybGFuZA==",
+			},
+			expectError: false,
+		},
+		{
+			name:  "multiple-items-base64",
+			input: "hello=d29uZGVybGFuZA==,private=ZXll",
+
+			expected: map[string]string{
+				"hello":   "d29uZGVybGFuZA==",
+				"private": "ZXll",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, testCase := range testData {
+		t.Logf("[DEBUG] Test %q", testCase.name)
+
+		actual, err := parseProperties(testCase.input)
+		if err != nil {
+			if testCase.expectError {
+				continue
+			}
+
+			t.Fatalf("[DEBUG] Didn't expect an error but got %s", err)
+		}
+		if !reflect.DeepEqual(testCase.expected, *actual) {
+			t.Fatalf("Expected %+v but got %+v", testCase.expected, *actual)
+		}
+	}
+}

--- a/storage/2018-11-09/datalakestore/filesystems/lifecycle_test.go
+++ b/storage/2018-11-09/datalakestore/filesystems/lifecycle_test.go
@@ -1,0 +1,83 @@
+package filesystems
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/storage/mgmt/storage"
+	"github.com/tombuildsstuff/giovanni/testhelpers"
+)
+
+func TestLifecycle(t *testing.T) {
+	client, err := testhelpers.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.TODO()
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	fileSystemName := fmt.Sprintf("acctestfs-%s", testhelpers.RandomString())
+
+	if _, err = client.BuildTestResources(ctx, resourceGroup, accountName, storage.BlobStorage); err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+	fileSystemsClient := NewWithEnvironment(client.Environment)
+	fileSystemsClient.Client = client.PrepareWithStorageResourceManagerAuth(fileSystemsClient.Client)
+
+	t.Logf("[DEBUG] Creating an empty File System..")
+	input := CreateInput{
+		Properties: map[string]string{
+			"hello": "aGVsbG8=",
+		},
+	}
+	if _, err = fileSystemsClient.Create(ctx, accountName, fileSystemName, input); err != nil {
+		t.Fatal(fmt.Errorf("Error creating: %s", err))
+	}
+
+	t.Logf("[DEBUG] Retrieving the Properties..")
+	props, err := fileSystemsClient.GetProperties(ctx, accountName, fileSystemName)
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error getting properties: %s", err))
+	}
+
+	if len(props.Properties) != 1 {
+		t.Fatalf("Expected 1 properties by default but got %d", len(props.Properties))
+	}
+	if props.Properties["hello"] != "aGVsbG8=" {
+		t.Fatalf("Expected `hello` to be `aGVsbG8=` but got %q", props.Properties["hello"])
+	}
+
+	t.Logf("[DEBUG] Updating the properties..")
+	setInput := SetPropertiesInput{
+		Properties: map[string]string{
+			"hello":   "d29uZGVybGFuZA==",
+			"private": "ZXll",
+		},
+	}
+	if _, err := fileSystemsClient.SetProperties(ctx, accountName, fileSystemName, setInput); err != nil {
+		t.Fatalf("Error setting properties: %s", err)
+	}
+
+	t.Logf("[DEBUG] Re-Retrieving the Properties..")
+	props, err = fileSystemsClient.GetProperties(ctx, accountName, fileSystemName)
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error getting properties: %s", err))
+	}
+	if len(props.Properties) != 2 {
+		t.Fatalf("Expected 2 properties by default but got %d", len(props.Properties))
+	}
+	if props.Properties["hello"] != "d29uZGVybGFuZA==" {
+		t.Fatalf("Expected `hello` to be `d29uZGVybGFuZA==` but got %q", props.Properties["hello"])
+	}
+	if props.Properties["private"] != "ZXll" {
+		t.Fatalf("Expected `private` to be `ZXll` but got %q", props.Properties["private"])
+	}
+
+	t.Logf("[DEBUG] Deleting File System..")
+	if _, err := fileSystemsClient.Delete(ctx, accountName, fileSystemName); err != nil {
+		t.Fatalf("Error deleting: %s", err)
+	}
+}

--- a/storage/2018-11-09/datalakestore/filesystems/properties_get.go
+++ b/storage/2018-11-09/datalakestore/filesystems/properties_get.go
@@ -1,0 +1,112 @@
+package filesystems
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+type GetPropertiesResponse struct {
+	autorest.Response
+
+	// A map of base64-encoded strings to store as user-defined properties with the File System
+	// Note that items may only contain ASCII characters in the ISO-8859-1 character set.
+	// This automatically gets converted to a comma-separated list of name and
+	// value pairs before sending to the API
+	Properties map[string]string
+
+	// Is Hierarchical Namespace Enabled?
+	NamespaceEnabled bool
+}
+
+// GetProperties gets the properties for a Data Lake Store Gen2 FileSystem within a Storage Account
+func (client Client) GetProperties(ctx context.Context, accountName string, fileSystemName string) (result GetPropertiesResponse, err error) {
+	if accountName == "" {
+		return result, validation.NewError("datalakestore.Client", "GetProperties", "`accountName` cannot be an empty string.")
+	}
+	if fileSystemName == "" {
+		return result, validation.NewError("datalakestore.Client", "GetProperties", "`fileSystemName` cannot be an empty string.")
+	}
+
+	req, err := client.GetPropertiesPreparer(ctx, accountName, fileSystemName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "GetProperties", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.GetPropertiesSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "GetProperties", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.GetPropertiesResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "GetProperties", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// GetPropertiesPreparer prepares the GetProperties request.
+func (client Client) GetPropertiesPreparer(ctx context.Context, accountName string, fileSystemName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"fileSystemName": autorest.Encode("path", fileSystemName),
+	}
+
+	queryParameters := map[string]interface{}{
+		"resource": autorest.Encode("query", "filesystem"),
+	}
+
+	headers := map[string]interface{}{
+		"x-ms-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsHead(),
+		autorest.WithBaseURL(endpoints.GetDataLakeStoreEndpoint(client.BaseURI, accountName)),
+		autorest.WithPathParameters("/{fileSystemName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters),
+		autorest.WithHeaders(headers))
+
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// GetPropertiesSender sends the GetProperties request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) GetPropertiesSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// GetPropertiesResponder handles the response to the GetProperties request. The method always
+// closes the http.Response Body.
+func (client Client) GetPropertiesResponder(resp *http.Response) (result GetPropertiesResponse, err error) {
+	if resp != nil && resp.Header != nil {
+
+		propertiesRaw := resp.Header.Get("x-ms-properties")
+		var properties *map[string]string
+		properties, err = parseProperties(propertiesRaw)
+		if err != nil {
+			return
+		}
+
+		result.Properties = *properties
+		result.NamespaceEnabled = strings.EqualFold(resp.Header.Get("x-ms-namespace-enabled"), "tru")
+	}
+
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+
+	return
+}

--- a/storage/2018-11-09/datalakestore/filesystems/properties_set.go
+++ b/storage/2018-11-09/datalakestore/filesystems/properties_set.go
@@ -1,0 +1,109 @@
+package filesystems
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+type SetPropertiesInput struct {
+	// A map of base64-encoded strings to store as user-defined properties with the File System
+	// Note that items may only contain ASCII characters in the ISO-8859-1 character set.
+	// This automatically gets converted to a comma-separated list of name and
+	// value pairs before sending to the API
+	Properties map[string]string
+
+	// Optional - A date and time value.
+	// Specify this header to perform the operation only if the resource has been modified since the specified date and time.
+	IfModifiedSince *string
+
+	// Optional - A date and time value.
+	// Specify this header to perform the operation only if the resource has not been modified since the specified date and time.
+	IfUnmodifiedSince *string
+}
+
+// SetProperties sets the Properties for a Data Lake Store Gen2 FileSystem within a Storage Account
+func (client Client) SetProperties(ctx context.Context, accountName string, fileSystemName string, input SetPropertiesInput) (result autorest.Response, err error) {
+	if accountName == "" {
+		return result, validation.NewError("datalakestore.Client", "SetProperties", "`accountName` cannot be an empty string.")
+	}
+	if fileSystemName == "" {
+		return result, validation.NewError("datalakestore.Client", "SetProperties", "`fileSystemName` cannot be an empty string.")
+	}
+
+	req, err := client.SetPropertiesPreparer(ctx, accountName, fileSystemName, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "SetProperties", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.SetPropertiesSender(req)
+	if err != nil {
+		result = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "SetProperties", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.SetPropertiesResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "SetProperties", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// SetPropertiesPreparer prepares the SetProperties request.
+func (client Client) SetPropertiesPreparer(ctx context.Context, accountName string, fileSystemName string, input SetPropertiesInput) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"fileSystemName": autorest.Encode("path", fileSystemName),
+	}
+
+	queryParameters := map[string]interface{}{
+		"resource": autorest.Encode("query", "filesystem"),
+	}
+
+	headers := map[string]interface{}{
+		"x-ms-properties": buildProperties(input.Properties),
+		"x-ms-version":    APIVersion,
+	}
+
+	if input.IfModifiedSince != nil {
+		headers["If-Modified-Since"] = *input.IfModifiedSince
+	}
+	if input.IfUnmodifiedSince != nil {
+		headers["If-Unmodified-Since"] = *input.IfUnmodifiedSince
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsPatch(),
+		autorest.WithBaseURL(endpoints.GetDataLakeStoreEndpoint(client.BaseURI, accountName)),
+		autorest.WithPathParameters("/{fileSystemName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters),
+		autorest.WithHeaders(headers))
+
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// SetPropertiesSender sends the SetProperties request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) SetPropertiesSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// SetPropertiesResponder handles the response to the SetProperties request. The method always
+// closes the http.Response Body.
+func (client Client) SetPropertiesResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+	result = autorest.Response{Response: resp}
+
+	return
+}

--- a/storage/2018-11-09/datalakestore/filesystems/resource_id.go
+++ b/storage/2018-11-09/datalakestore/filesystems/resource_id.go
@@ -1,0 +1,46 @@
+package filesystems
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+// GetResourceID returns the Resource ID for the given Data Lake Storage FileSystem
+// This can be useful when, for example, you're using this as a unique identifier
+func (client Client) GetResourceID(accountName, shareName string) string {
+	domain := endpoints.GetDataLakeStoreEndpoint(client.BaseURI, accountName)
+	return fmt.Sprintf("%s/%s", domain, shareName)
+}
+
+type ResourceID struct {
+	AccountName   string
+	DirectoryName string
+}
+
+// ParseResourceID parses the specified Resource ID and returns an object
+// which can be used to interact with the Data Lake Storage FileSystem API's
+func ParseResourceID(id string) (*ResourceID, error) {
+	// example: https://foo.dfs.core.windows.net/Bar
+	if id == "" {
+		return nil, fmt.Errorf("`id` was empty")
+	}
+
+	uri, err := url.Parse(id)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing ID as a URL: %s", err)
+	}
+
+	accountName, err := endpoints.GetAccountNameFromEndpoint(uri.Host)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing Account Name: %s", err)
+	}
+
+	directoryName := strings.TrimPrefix(uri.Path, "/")
+	return &ResourceID{
+		AccountName:   *accountName,
+		DirectoryName: directoryName,
+	}, nil
+}

--- a/storage/2018-11-09/datalakestore/filesystems/resource_id_test.go
+++ b/storage/2018-11-09/datalakestore/filesystems/resource_id_test.go
@@ -1,0 +1,78 @@
+package filesystems
+
+import (
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+func TestGetResourceID(t *testing.T) {
+	testData := []struct {
+		Environment azure.Environment
+		Expected    string
+	}{
+		{
+			Environment: azure.ChinaCloud,
+			Expected:    "https://account1.dfs.core.chinacloudapi.cn/directory1",
+		},
+		{
+			Environment: azure.GermanCloud,
+			Expected:    "https://account1.dfs.core.cloudapi.de/directory1",
+		},
+		{
+			Environment: azure.PublicCloud,
+			Expected:    "https://account1.dfs.core.windows.net/directory1",
+		},
+		{
+			Environment: azure.USGovernmentCloud,
+			Expected:    "https://account1.dfs.core.usgovcloudapi.net/directory1",
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
+		c := NewWithEnvironment(v.Environment)
+		actual := c.GetResourceID("account1", "directory1")
+		if actual != v.Expected {
+			t.Fatalf("Expected the Resource ID to be %q but got %q", v.Expected, actual)
+		}
+	}
+}
+
+func TestParseResourceID(t *testing.T) {
+	testData := []struct {
+		Environment azure.Environment
+		Input       string
+	}{
+		{
+			Environment: azure.ChinaCloud,
+			Input:       "https://account1.dfs.core.chinacloudapi.cn/directory1",
+		},
+		{
+			Environment: azure.GermanCloud,
+			Input:       "https://account1.dfs.core.cloudapi.de/directory1",
+		},
+		{
+			Environment: azure.PublicCloud,
+			Input:       "https://account1.dfs.core.windows.net/directory1",
+		},
+		{
+			Environment: azure.USGovernmentCloud,
+			Input:       "https://account1.dfs.core.usgovcloudapi.net/directory1",
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
+		actual, err := ParseResourceID(v.Input)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if actual.AccountName != "account1" {
+			t.Fatalf("Expected the account name to be `account1` but got %q", actual.AccountName)
+		}
+
+		if actual.DirectoryName != "directory1" {
+			t.Fatalf("Expected the directory name to be `directory1` but got %q", actual.DirectoryName)
+		}
+	}
+}

--- a/storage/2018-11-09/datalakestore/filesystems/version.go
+++ b/storage/2018-11-09/datalakestore/filesystems/version.go
@@ -1,0 +1,14 @@
+package filesystems
+
+import (
+	"fmt"
+
+	"github.com/tombuildsstuff/giovanni/version"
+)
+
+// APIVersion is the version of the API used for all Storage API Operations
+const APIVersion = "2018-11-09"
+
+func UserAgent() string {
+	return fmt.Sprintf("tombuildsstuff/giovanni/%s storage/%s", version.Number, APIVersion)
+}

--- a/storage/internal/endpoints/endpoints.go
+++ b/storage/internal/endpoints/endpoints.go
@@ -18,6 +18,11 @@ func GetBlobEndpoint(baseUri string, accountName string) string {
 	return fmt.Sprintf("https://%s.blob.%s", accountName, baseUri)
 }
 
+// GetDataLakeStoreEndpoint returns the endpoint for Data Lake Store API Operations on this storage account
+func GetDataLakeStoreEndpoint(baseUri string, accountName string) string {
+	return fmt.Sprintf("https://%s.dfs.%s", accountName, baseUri)
+}
+
 // GetFileEndpoint returns the endpoint for File Share API Operations on this storage account
 func GetFileEndpoint(baseUri string, accountName string) string {
 	return fmt.Sprintf("https://%s.file.%s", accountName, baseUri)

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Number = "v0.4.0"
+const Number = "v0.5.0"


### PR DESCRIPTION
This PR introduces support for [DataLakeStorage Gen2 File Systems](https://docs.microsoft.com/en-gb/rest/api/storageservices/data-lake-storage-gen2) for API versions `2018-11-09` and `2018-03-28` (it's unavailable for `2017-07-29)

Fixes #10

---

Tests pass for API Version `2018-11-09`:

```
$ envchain azurerm go test -v ./storage/2018-11-09/datalakestore/filesystems/
=== RUN   TestCreateHasNoTagsByDefault
2019/09/06 12:36:37 Testing if Service Principal / Client Certificate is applicable for Authentication..
2019/09/06 12:36:37 Testing if Service Principal / Client Secret is applicable for Authentication..
2019/09/06 12:36:37 Using Service Principal / Client Secret for Authentication
--- PASS: TestCreateHasNoTagsByDefault (77.76s)
    create_test.go:31: [DEBUG] Creating an empty File System..
    create_test.go:39: [DEBUG] Retrieving the Properties..
    create_test.go:49: [DEBUG] Deleting File System..
=== RUN   TestParseProperties
--- PASS: TestParseProperties (0.00s)
    helpers_test.go:62: [DEBUG] Test "no items"
    helpers_test.go:62: [DEBUG] Test "invalid item"
    helpers_test.go:62: [DEBUG] Test "single item"
    helpers_test.go:62: [DEBUG] Test "single-item-base64"
    helpers_test.go:62: [DEBUG] Test "single-item-base64-multipleequals"
    helpers_test.go:62: [DEBUG] Test "multiple-items-base64"
=== RUN   TestLifecycle
2019/09/06 12:37:55 Testing if Service Principal / Client Certificate is applicable for Authentication..
2019/09/06 12:37:55 Testing if Service Principal / Client Secret is applicable for Authentication..
2019/09/06 12:37:55 Using Service Principal / Client Secret for Authentication
--- PASS: TestLifecycle (75.87s)
    lifecycle_test.go:30: [DEBUG] Creating an empty File System..
    lifecycle_test.go:40: [DEBUG] Retrieving the Properties..
    lifecycle_test.go:53: [DEBUG] Updating the properties..
    lifecycle_test.go:64: [DEBUG] Re-Retrieving the Properties..
    lifecycle_test.go:79: [DEBUG] Deleting File System..
=== RUN   TestGetResourceID
--- PASS: TestGetResourceID (0.00s)
    resource_id_test.go:32: [DEBUG] Testing Environment "AzureChinaCloud"
    resource_id_test.go:32: [DEBUG] Testing Environment "AzureGermanCloud"
    resource_id_test.go:32: [DEBUG] Testing Environment "AzurePublicCloud"
    resource_id_test.go:32: [DEBUG] Testing Environment "AzureUSGovernmentCloud"
=== RUN   TestParseResourceID
--- PASS: TestParseResourceID (0.00s)
    resource_id_test.go:64: [DEBUG] Testing Environment "AzureChinaCloud"
    resource_id_test.go:64: [DEBUG] Testing Environment "AzureGermanCloud"
    resource_id_test.go:64: [DEBUG] Testing Environment "AzurePublicCloud"
    resource_id_test.go:64: [DEBUG] Testing Environment "AzureUSGovernmentCloud"
PASS
ok  	github.com/tombuildsstuff/giovanni/storage/2018-11-09/datalakestore/filesystems	153.647s
```

and API Version `2018-03-28`:

```
$ envchain azurerm go test -v ./storage/2018-03-28/datalakestore/filesystems/
=== RUN   TestCreateHasNoTagsByDefault
2019/09/06 12:27:24 Testing if Service Principal / Client Certificate is applicable for Authentication..
2019/09/06 12:27:24 Testing if Service Principal / Client Secret is applicable for Authentication..
2019/09/06 12:27:24 Using Service Principal / Client Secret for Authentication
--- PASS: TestCreateHasNoTagsByDefault (76.71s)
    create_test.go:31: [DEBUG] Creating an empty File System..
    create_test.go:39: [DEBUG] Retrieving the Properties..
    create_test.go:49: [DEBUG] Deleting File System..
=== RUN   TestParseProperties
--- PASS: TestParseProperties (0.00s)
    helpers_test.go:62: [DEBUG] Test "no items"
    helpers_test.go:62: [DEBUG] Test "invalid item"
    helpers_test.go:62: [DEBUG] Test "single item"
    helpers_test.go:62: [DEBUG] Test "single-item-base64"
    helpers_test.go:62: [DEBUG] Test "single-item-base64-multipleequals"
    helpers_test.go:62: [DEBUG] Test "multiple-items-base64"
=== RUN   TestLifecycle
2019/09/06 12:28:41 Testing if Service Principal / Client Certificate is applicable for Authentication..
2019/09/06 12:28:41 Testing if Service Principal / Client Secret is applicable for Authentication..
2019/09/06 12:28:41 Using Service Principal / Client Secret for Authentication
--- PASS: TestLifecycle (77.40s)
    lifecycle_test.go:30: [DEBUG] Creating an empty File System..
    lifecycle_test.go:40: [DEBUG] Retrieving the Properties..
    lifecycle_test.go:53: [DEBUG] Updating the properties..
    lifecycle_test.go:64: [DEBUG] Re-Retrieving the Properties..
    lifecycle_test.go:79: [DEBUG] Deleting File System..
=== RUN   TestGetResourceID
--- PASS: TestGetResourceID (0.00s)
    resource_id_test.go:32: [DEBUG] Testing Environment "AzureChinaCloud"
    resource_id_test.go:32: [DEBUG] Testing Environment "AzureGermanCloud"
    resource_id_test.go:32: [DEBUG] Testing Environment "AzurePublicCloud"
    resource_id_test.go:32: [DEBUG] Testing Environment "AzureUSGovernmentCloud"
=== RUN   TestParseResourceID
--- PASS: TestParseResourceID (0.00s)
    resource_id_test.go:64: [DEBUG] Testing Environment "AzureChinaCloud"
    resource_id_test.go:64: [DEBUG] Testing Environment "AzureGermanCloud"
    resource_id_test.go:64: [DEBUG] Testing Environment "AzurePublicCloud"
    resource_id_test.go:64: [DEBUG] Testing Environment "AzureUSGovernmentCloud"
PASS
ok  	github.com/tombuildsstuff/giovanni/storage/2018-03-28/datalakestore/filesystems	154.132s
```