### PR TITLE
Fix setting $filter in QueryPreparer

### DIFF
--- a/storage/2017-07-29/table/entities/query.go
+++ b/storage/2017-07-29/table/entities/query.go
@@ -96,7 +96,7 @@ func (client Client) QueryPreparer(ctx context.Context, accountName, tableName s
 	queryParameters := map[string]interface{}{}
 
 	if input.Filter != nil {
-		queryParameters["filter"] = autorest.Encode("query", input.Filter)
+		queryParameters["$filter"] = autorest.Encode("query", *input.Filter)
 	}
 
 	if input.PropertyNamesToSelect != nil {

--- a/storage/2018-03-28/table/entities/query.go
+++ b/storage/2018-03-28/table/entities/query.go
@@ -96,7 +96,7 @@ func (client Client) QueryPreparer(ctx context.Context, accountName, tableName s
 	queryParameters := map[string]interface{}{}
 
 	if input.Filter != nil {
-		queryParameters["filter"] = autorest.Encode("query", input.Filter)
+		queryParameters["$filter"] = autorest.Encode("query", *input.Filter)
 	}
 
 	if input.PropertyNamesToSelect != nil {

--- a/storage/2018-11-09/table/entities/query.go
+++ b/storage/2018-11-09/table/entities/query.go
@@ -96,7 +96,7 @@ func (client Client) QueryPreparer(ctx context.Context, accountName, tableName s
 	queryParameters := map[string]interface{}{}
 
 	if input.Filter != nil {
-		queryParameters["filter"] = autorest.Encode("query", input.Filter)
+		queryParameters["$filter"] = autorest.Encode("query", *input.Filter)
 	}
 
 	if input.PropertyNamesToSelect != nil {


### PR DESCRIPTION
Hi,

in our project we want to **query** Azure Tables. For querying the collection one must [request Table API](https://docs.microsoft.com/en-us/rest/api/storageservices/query-entities) with `$filter`  URL parameter.

In original code of the library there are two bugs:

1. wrong name of URL parameter - `filter`, must be `$filter`
2. wrong assignment of the value - value of the pointer must be referenced via `*` operator

I'm sending you the pull request to correct both bugs. Hope you merge and release it soon, it would help our team.