### PR TITLE
Add $top (limit) configuration to QueryEntitiesInput

### DIFF
--- a/storage/2017-07-29/table/entities/query.go
+++ b/storage/2017-07-29/table/entities/query.go
@@ -19,6 +19,9 @@ type QueryEntitiesInput struct {
 	// An optional comma-separated
 	PropertyNamesToSelect *[]string
 
+	// An optional OData top
+	Limit *int
+
 	PartitionKey string
 	RowKey       string
 
@@ -101,6 +104,10 @@ func (client Client) QueryPreparer(ctx context.Context, accountName, tableName s
 
 	if input.PropertyNamesToSelect != nil {
 		queryParameters["$select"] = autorest.Encode("query", strings.Join(*input.PropertyNamesToSelect, ","))
+	}
+
+	if input.Limit != nil {
+		queryParameters["$top"] = autorest.Encode("query", *input.Limit)
 	}
 
 	if input.NextPartitionKey != nil {

--- a/storage/2017-07-29/table/entities/query.go
+++ b/storage/2017-07-29/table/entities/query.go
@@ -20,7 +20,7 @@ type QueryEntitiesInput struct {
 	PropertyNamesToSelect *[]string
 
 	// An optional OData top
-	Limit *int
+	Top *int
 
 	PartitionKey string
 	RowKey       string
@@ -106,8 +106,8 @@ func (client Client) QueryPreparer(ctx context.Context, accountName, tableName s
 		queryParameters["$select"] = autorest.Encode("query", strings.Join(*input.PropertyNamesToSelect, ","))
 	}
 
-	if input.Limit != nil {
-		queryParameters["$top"] = autorest.Encode("query", *input.Limit)
+	if input.Top != nil {
+		queryParameters["$top"] = autorest.Encode("query", *input.Top)
 	}
 
 	if input.NextPartitionKey != nil {

--- a/storage/2018-03-28/table/entities/query.go
+++ b/storage/2018-03-28/table/entities/query.go
@@ -19,6 +19,9 @@ type QueryEntitiesInput struct {
 	// An optional comma-separated
 	PropertyNamesToSelect *[]string
 
+	// An optional OData top
+	Limit *int
+
 	PartitionKey string
 	RowKey       string
 
@@ -101,6 +104,10 @@ func (client Client) QueryPreparer(ctx context.Context, accountName, tableName s
 
 	if input.PropertyNamesToSelect != nil {
 		queryParameters["$select"] = autorest.Encode("query", strings.Join(*input.PropertyNamesToSelect, ","))
+	}
+
+	if input.Limit != nil {
+		queryParameters["$top"] = autorest.Encode("query", *input.Limit)
 	}
 
 	if input.NextPartitionKey != nil {

--- a/storage/2018-03-28/table/entities/query.go
+++ b/storage/2018-03-28/table/entities/query.go
@@ -20,7 +20,7 @@ type QueryEntitiesInput struct {
 	PropertyNamesToSelect *[]string
 
 	// An optional OData top
-	Limit *int
+	Top *int
 
 	PartitionKey string
 	RowKey       string
@@ -106,8 +106,8 @@ func (client Client) QueryPreparer(ctx context.Context, accountName, tableName s
 		queryParameters["$select"] = autorest.Encode("query", strings.Join(*input.PropertyNamesToSelect, ","))
 	}
 
-	if input.Limit != nil {
-		queryParameters["$top"] = autorest.Encode("query", *input.Limit)
+	if input.Top != nil {
+		queryParameters["$top"] = autorest.Encode("query", *input.Top)
 	}
 
 	if input.NextPartitionKey != nil {

--- a/storage/2018-11-09/table/entities/query.go
+++ b/storage/2018-11-09/table/entities/query.go
@@ -19,6 +19,9 @@ type QueryEntitiesInput struct {
 	// An optional comma-separated
 	PropertyNamesToSelect *[]string
 
+	// An optional OData top
+	Limit *int
+
 	PartitionKey string
 	RowKey       string
 
@@ -101,6 +104,10 @@ func (client Client) QueryPreparer(ctx context.Context, accountName, tableName s
 
 	if input.PropertyNamesToSelect != nil {
 		queryParameters["$select"] = autorest.Encode("query", strings.Join(*input.PropertyNamesToSelect, ","))
+	}
+
+	if input.Limit != nil {
+		queryParameters["$top"] = autorest.Encode("query", *input.Limit)
 	}
 
 	if input.NextPartitionKey != nil {

--- a/storage/2018-11-09/table/entities/query.go
+++ b/storage/2018-11-09/table/entities/query.go
@@ -20,7 +20,7 @@ type QueryEntitiesInput struct {
 	PropertyNamesToSelect *[]string
 
 	// An optional OData top
-	Limit *int
+	Top *int
 
 	PartitionKey string
 	RowKey       string
@@ -106,8 +106,8 @@ func (client Client) QueryPreparer(ctx context.Context, accountName, tableName s
 		queryParameters["$select"] = autorest.Encode("query", strings.Join(*input.PropertyNamesToSelect, ","))
 	}
 
-	if input.Limit != nil {
-		queryParameters["$top"] = autorest.Encode("query", *input.Limit)
+	if input.Top != nil {
+		queryParameters["$top"] = autorest.Encode("query", *input.Top)
 	}
 
 	if input.NextPartitionKey != nil {


### PR DESCRIPTION
Hi,

when querying Azure Table **collection** you can configure optional URL parameter `$top` which is defacto a limit parameter (know for example from SQL).
With this you can limit number of returned table entities.

In this simple pull request I added code for configuring `$top` parameter in table queries.