### PR TITLE
containers/shares: adding methods to get the Resource Manager ID

### DIFF
--- a/storage/2018-11-09/blob/containers/resource_id.go
+++ b/storage/2018-11-09/blob/containers/resource_id.go
@@ -15,6 +15,13 @@ func (client Client) GetResourceID(accountName, containerName string) string {
 	return fmt.Sprintf("%s/%s", domain, containerName)
 }
 
+// GetResourceManagerResourceID returns the Resource Manager specific
+// ResourceID for a specific Storage Container
+func (client Client) GetResourceManagerResourceID(subscriptionID, resourceGroup, accountName, containerName string) string {
+	fmtStr := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/blobServices/default/containers/%s"
+	return fmt.Sprintf(fmtStr, subscriptionID, resourceGroup, accountName, containerName)
+}
+
 type ResourceID struct {
 	AccountName   string
 	ContainerName string

--- a/storage/2018-11-09/blob/containers/resource_id_test.go
+++ b/storage/2018-11-09/blob/containers/resource_id_test.go
@@ -38,6 +38,38 @@ func TestGetResourceID(t *testing.T) {
 	}
 }
 
+func TestGetResourceManagerResourceID(t *testing.T) {
+	testData := []struct {
+		Environment azure.Environment
+		Expected    string
+	}{
+		{
+			Environment: azure.ChinaCloud,
+			Expected:    "/subscriptions/11112222-3333-4444-5555-666677778888/resourceGroups/group1/providers/Microsoft.Storage/storageAccounts/account1/blobServices/default/containers/container1",
+		},
+		{
+			Environment: azure.GermanCloud,
+			Expected:    "/subscriptions/11112222-3333-4444-5555-666677778888/resourceGroups/group1/providers/Microsoft.Storage/storageAccounts/account1/blobServices/default/containers/container1",
+		},
+		{
+			Environment: azure.PublicCloud,
+			Expected:    "/subscriptions/11112222-3333-4444-5555-666677778888/resourceGroups/group1/providers/Microsoft.Storage/storageAccounts/account1/blobServices/default/containers/container1",
+		},
+		{
+			Environment: azure.USGovernmentCloud,
+			Expected:    "/subscriptions/11112222-3333-4444-5555-666677778888/resourceGroups/group1/providers/Microsoft.Storage/storageAccounts/account1/blobServices/default/containers/container1",
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
+		c := NewWithEnvironment(v.Environment)
+		actual := c.GetResourceManagerResourceID("11112222-3333-4444-5555-666677778888", "group1", "account1", "container1")
+		if actual != v.Expected {
+			t.Fatalf("Expected the Resource Manager Resource ID to be %q but got %q", v.Expected, actual)
+		}
+	}
+}
+
 func TestParseResourceID(t *testing.T) {
 	testData := []struct {
 		Environment azure.Environment

--- a/storage/2018-11-09/file/shares/resource_id.go
+++ b/storage/2018-11-09/file/shares/resource_id.go
@@ -15,6 +15,13 @@ func (client Client) GetResourceID(accountName, shareName string) string {
 	return fmt.Sprintf("%s/%s", domain, shareName)
 }
 
+// GetResourceManagerResourceID returns the Resource Manager specific
+// ResourceID for a specific Storage Share
+func (client Client) GetResourceManagerResourceID(subscriptionID, resourceGroup, accountName, shareName string) string {
+	fmtStr := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/fileServices/default/shares/%s"
+	return fmt.Sprintf(fmtStr, subscriptionID, resourceGroup, accountName, shareName)
+}
+
 type ResourceID struct {
 	AccountName string
 	ShareName   string

--- a/storage/2018-11-09/file/shares/resource_id_test.go
+++ b/storage/2018-11-09/file/shares/resource_id_test.go
@@ -38,6 +38,38 @@ func TestGetResourceID(t *testing.T) {
 	}
 }
 
+func TestGetResourceManagerResourceID(t *testing.T) {
+	testData := []struct {
+		Environment azure.Environment
+		Expected    string
+	}{
+		{
+			Environment: azure.ChinaCloud,
+			Expected:    "/subscriptions/11112222-3333-4444-5555-666677778888/resourceGroups/group1/providers/Microsoft.Storage/storageAccounts/account1/fileServices/default/shares/share1",
+		},
+		{
+			Environment: azure.GermanCloud,
+			Expected:    "/subscriptions/11112222-3333-4444-5555-666677778888/resourceGroups/group1/providers/Microsoft.Storage/storageAccounts/account1/fileServices/default/shares/share1",
+		},
+		{
+			Environment: azure.PublicCloud,
+			Expected:    "/subscriptions/11112222-3333-4444-5555-666677778888/resourceGroups/group1/providers/Microsoft.Storage/storageAccounts/account1/fileServices/default/shares/share1",
+		},
+		{
+			Environment: azure.USGovernmentCloud,
+			Expected:    "/subscriptions/11112222-3333-4444-5555-666677778888/resourceGroups/group1/providers/Microsoft.Storage/storageAccounts/account1/fileServices/default/shares/share1",
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
+		c := NewWithEnvironment(v.Environment)
+		actual := c.GetResourceManagerResourceID("11112222-3333-4444-5555-666677778888", "group1", "account1", "share1")
+		if actual != v.Expected {
+			t.Fatalf("Expected the Resource Manager Resource ID to be %q but got %q", v.Expected, actual)
+		}
+	}
+}
+
 func TestParseResourceID(t *testing.T) {
 	testData := []struct {
 		Environment azure.Environment


### PR DESCRIPTION
This PR introduces a couple of methods to the Containers & Shares SDK's to get the Resource Manager ID for these resources. This is required since these resources can be referenced/managed by either the Data Plane API's or the Resource Manager API's