### PR TITLE
Add support for directory creation in ADLS accounts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/Azure/azure-sdk-for-go v32.5.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.9.0
-	github.com/Azure/go-autorest/autorest/adal v0.8.0
+	github.com/Azure/go-autorest/autorest/adal v0.8.2
 	github.com/Azure/go-autorest/autorest/azure/cli v0.3.0 // indirect
 	github.com/Azure/go-autorest/autorest/to v0.3.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.2.0
@@ -13,4 +13,8 @@ require (
 	github.com/hashicorp/go-azure-helpers v0.4.1
 )
 
-replace github.com/Azure/go-autorest/autorest => github.com/tombuildsstuff/go-autorest/autorest v0.9.3-hashi-auth
+replace github.com/Azure/go-autorest => github.com/tombuildsstuff/go-autorest v14.0.1-0.20200416184303-d4e299a3c04a+incompatible
+
+replace github.com/Azure/go-autorest/autorest => github.com/tombuildsstuff/go-autorest/autorest v0.10.1-0.20200416184303-d4e299a3c04a
+
+replace github.com/Azure/go-autorest/autorest/azure/auth => github.com/tombuildsstuff/go-autorest/autorest/azure/auth v0.4.3-0.20200416184303-d4e299a3c04a

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,9 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.3.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.2.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-azure-helpers v0.4.1
+	github.com/stretchr/testify v1.3.0
 )
 
 replace github.com/Azure/go-autorest => github.com/tombuildsstuff/go-autorest v14.0.1-0.20200416184303-d4e299a3c04a+incompatible

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/Azure/go-autorest/autorest/adal v0.6.0 h1:UCTq22yE3RPgbU/8u4scfnnzuCW
 github.com/Azure/go-autorest/autorest/adal v0.6.0/go.mod h1:Z6vX6WXXuyieHAXwMj0S6HY6e6wcHn37qQMBQlvY3lc=
 github.com/Azure/go-autorest/autorest/adal v0.8.0 h1:CxTzQrySOxDnKpLjFJeZAS5Qrv/qFPkgLjx5bOAi//I=
 github.com/Azure/go-autorest/autorest/adal v0.8.0/go.mod h1:Z6vX6WXXuyieHAXwMj0S6HY6e6wcHn37qQMBQlvY3lc=
+github.com/Azure/go-autorest/autorest/adal v0.8.2 h1:O1X4oexUxnZCaEUGsvMnr8ZGj8HI37tNezwY4npRqA0=
+github.com/Azure/go-autorest/autorest/adal v0.8.2/go.mod h1:ZjhuQClTqx435SRJ2iMlOxPYt3d2C/T/7TiQCVZSn3Q=
 github.com/Azure/go-autorest/autorest/azure/cli v0.3.0 h1:5PAqnv+CSTwW9mlZWZAizmzrazFWEgZykEZXpr2hDtY=
 github.com/Azure/go-autorest/autorest/azure/cli v0.3.0/go.mod h1:rNYMNAefZMRowqCV0cVhr/YDW5dD7afFq9nXAXL4ykE=
 github.com/Azure/go-autorest/autorest/date v0.2.0 h1:yW+Zlqf26583pE43KhfnhFcdmSWlm5Ew6bxipnr/tbM=
@@ -45,8 +47,12 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/tombuildsstuff/go-autorest v14.0.1-0.20200416184303-d4e299a3c04a+incompatible h1:9645FYqYopS+TFknygW7EC9PCbIC5T4WvWUpktyE2JA=
+github.com/tombuildsstuff/go-autorest v14.0.1-0.20200416184303-d4e299a3c04a+incompatible/go.mod h1:OVwh0+NZeL2RTqclVEX+p20Qys7Ihpd52PD0eqFDXtY=
 github.com/tombuildsstuff/go-autorest/autorest v0.9.3-hashi-auth h1:lxCuE8Hd/BZmXTK/v7/isjw7K4g8UDci0EC87UeK6BY=
 github.com/tombuildsstuff/go-autorest/autorest v0.9.3-hashi-auth/go.mod h1:GsRuLYvwzLjjjRoWEIyMUaYq8GNUx2nRB378IPt/1p0=
+github.com/tombuildsstuff/go-autorest/autorest v0.10.1-0.20200416184303-d4e299a3c04a h1:F/4zKpn8ra3rhPMBzrVc7LYL1GB1ucl/va4I+4ubUWg=
+github.com/tombuildsstuff/go-autorest/autorest v0.10.1-0.20200416184303-d4e299a3c04a/go.mod h1:/FALq9T/kS7b5J5qsQ+RSTUdAmGFqi0vUdVNNx8q630=
 golang.org/x/crypto v0.0.0-20181112202954-3d3f9f413869/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/dimchansky/utfbom v1.0.0 h1:fGC2kkf4qOoKqZ4q7iIh+Vef4ubC1c38UDsEyZynZ
 github.com/dimchansky/utfbom v1.0.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.0 h1:FcM3g+nofKgUteL8dm/UpdRXNC9KmADgTpLKsu0TRo4=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.4.1 h1:aEWYW4hxAVVmxmq7nPXGK8F44A6HBXQ4m0vB1M3/20g=

--- a/storage/2018-11-09/datalakestore/paths/client.go
+++ b/storage/2018-11-09/datalakestore/paths/client.go
@@ -1,0 +1,25 @@
+package paths
+
+import (
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Client is the base client for Data Lake Storage Path
+type Client struct {
+	autorest.Client
+	BaseURI string
+}
+
+// New creates an instance of the Data Lake Storage Path client.
+func New() Client {
+	return NewWithEnvironment(azure.PublicCloud)
+}
+
+// NewWithEnvironment creates an instance of the Data Lake Storage Path client.
+func NewWithEnvironment(environment azure.Environment) Client {
+	return Client{
+		Client:  autorest.NewClientWithUserAgent(UserAgent()),
+		BaseURI: environment.StorageEndpointSuffix,
+	}
+}

--- a/storage/2018-11-09/datalakestore/paths/create.go
+++ b/storage/2018-11-09/datalakestore/paths/create.go
@@ -1,0 +1,95 @@
+package paths
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+type PathResource string
+
+const PathResourceFile PathResource = "file"
+const PathResourceDirectory PathResource = "directory"
+
+type CreateInput struct {
+	Resource PathResource
+}
+
+// Create creates a Data Lake Store Gen2 Path within a Storage Account
+func (client Client) Create(ctx context.Context, accountName string, fileSystemName string, path string, input CreateInput) (result autorest.Response, err error) {
+	if accountName == "" {
+		return result, validation.NewError("datalakestore.Client", "Create", "`accountName` cannot be an empty string.")
+	}
+	if fileSystemName == "" {
+		return result, validation.NewError("datalakestore.Client", "Create", "`fileSystemName` cannot be an empty string.")
+	}
+
+	req, err := client.CreatePreparer(ctx, accountName, fileSystemName, path, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "Create", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.CreateSender(req)
+	if err != nil {
+		result = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "Create", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.CreateResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "Create", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// CreatePreparer prepares the Create request.
+func (client Client) CreatePreparer(ctx context.Context, accountName string, fileSystemName string, path string, input CreateInput) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"fileSystemName": autorest.Encode("path", fileSystemName),
+		"path":           autorest.Encode("path", path),
+	}
+
+	queryParameters := map[string]interface{}{
+		"resource": autorest.Encode("query", input.Resource),
+	}
+
+	headers := map[string]interface{}{
+		"x-ms-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsPut(),
+		autorest.WithBaseURL(endpoints.GetDataLakeStoreEndpoint(client.BaseURI, accountName)),
+		autorest.WithPathParameters("/{fileSystemName}/{path}", pathParameters),
+		autorest.WithQueryParameters(queryParameters),
+		autorest.WithHeaders(headers))
+
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// CreateSender sends the Create request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) CreateSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// CreateResponder handles the response to the Create request. The method always
+// closes the http.Response Body.
+func (client Client) CreateResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusCreated),
+		autorest.ByClosing())
+	result = autorest.Response{Response: resp}
+
+	return
+}

--- a/storage/2018-11-09/datalakestore/paths/create_test.go
+++ b/storage/2018-11-09/datalakestore/paths/create_test.go
@@ -1,0 +1,57 @@
+package paths
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/storage/mgmt/storage"
+	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/datalakestore/filesystems"
+	"github.com/tombuildsstuff/giovanni/testhelpers"
+)
+
+func TestCreateDirectory(t *testing.T) {
+	client, err := testhelpers.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.TODO()
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	fileSystemName := fmt.Sprintf("acctestfs-%s", testhelpers.RandomString())
+	path := "test"
+
+	if _, err = client.BuildTestResources(ctx, resourceGroup, accountName, storage.BlobStorage); err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	fileSystemsClient := filesystems.NewWithEnvironment(client.Environment)
+	fileSystemsClient.Client = client.PrepareWithStorageResourceManagerAuth(fileSystemsClient.Client)
+
+	t.Logf("[DEBUG] Creating an empty File System..")
+	fileSystemInput := filesystems.CreateInput{
+		Properties: map[string]string{},
+	}
+	if _, err = fileSystemsClient.Create(ctx, accountName, fileSystemName, fileSystemInput); err != nil {
+		t.Fatal(fmt.Errorf("Error creating: %s", err))
+	}
+
+	t.Logf("[DEBUG] Creating path..")
+	pathsClient := NewWithEnvironment(client.Environment)
+	pathsClient.Client = client.PrepareWithStorageResourceManagerAuth(pathsClient.Client)
+
+	input := CreateInput{
+		Resource: PathResourceDirectory,
+	}
+
+	if _, err = pathsClient.Create(ctx, accountName, fileSystemName, path, input); err != nil {
+		t.Fatal(fmt.Errorf("Error creating path: %s", err))
+	}
+
+	t.Logf("[DEBUG] Deleting File System..")
+	if _, err := fileSystemsClient.Delete(ctx, accountName, fileSystemName); err != nil {
+		t.Fatalf("Error deleting: %s", err)
+	}
+}

--- a/storage/2018-11-09/datalakestore/paths/create_test.go
+++ b/storage/2018-11-09/datalakestore/paths/create_test.go
@@ -22,7 +22,7 @@ func TestCreateDirectory(t *testing.T) {
 	fileSystemName := fmt.Sprintf("acctestfs-%s", testhelpers.RandomString())
 	path := "test"
 
-	if _, err = client.BuildTestResources(ctx, resourceGroup, accountName, storage.BlobStorage); err != nil {
+	if _, err = client.BuildTestResourcesWithHns(ctx, resourceGroup, accountName, storage.BlobStorage); err != nil {
 		t.Fatal(err)
 	}
 	defer client.DestroyTestResources(ctx, resourceGroup, accountName)

--- a/storage/2018-11-09/datalakestore/paths/delete.go
+++ b/storage/2018-11-09/datalakestore/paths/delete.go
@@ -1,0 +1,81 @@
+package paths
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+// Delete deletes a Data Lake Store Gen2 FileSystem within a Storage Account
+func (client Client) Delete(ctx context.Context, accountName string, fileSystemName string, path string) (result autorest.Response, err error) {
+	if accountName == "" {
+		return result, validation.NewError("datalakestore.Client", "Delete", "`accountName` cannot be an empty string.")
+	}
+	if fileSystemName == "" {
+		return result, validation.NewError("datalakestore.Client", "Delete", "`fileSystemName` cannot be an empty string.")
+	}
+
+	req, err := client.DeletePreparer(ctx, accountName, fileSystemName, path)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.DeleteSender(req)
+	if err != nil {
+		result = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "Delete", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.DeleteResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "Delete", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// DeletePreparer prepares the Delete request.
+func (client Client) DeletePreparer(ctx context.Context, accountName string, fileSystemName string, path string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"fileSystemName": autorest.Encode("path", fileSystemName),
+		"path":           autorest.Encode("path", fileSystemName),
+	}
+
+	headers := map[string]interface{}{
+		"x-ms-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsDelete(),
+		autorest.WithBaseURL(endpoints.GetDataLakeStoreEndpoint(client.BaseURI, accountName)),
+		autorest.WithPathParameters("/{fileSystemName}/{path}", pathParameters),
+		autorest.WithHeaders(headers))
+
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// DeleteSender sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) DeleteSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// DeleteResponder handles the response to the Delete request. The method always
+// closes the http.Response Body.
+func (client Client) DeleteResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusAccepted),
+		autorest.ByClosing())
+	result = autorest.Response{Response: resp}
+
+	return
+}

--- a/storage/2018-11-09/datalakestore/paths/helpers.go
+++ b/storage/2018-11-09/datalakestore/paths/helpers.go
@@ -1,0 +1,15 @@
+package paths
+
+import (
+	"fmt"
+)
+
+func parsePathResource(input string) (PathResource, error) {
+	switch input {
+	case "file":
+		return PathResourceFile, nil
+	case "directory":
+		return PathResourceDirectory, nil
+	}
+	return "", fmt.Errorf("Unhandled path resource type %q", input)
+}

--- a/storage/2018-11-09/datalakestore/paths/lifecycle_test.go
+++ b/storage/2018-11-09/datalakestore/paths/lifecycle_test.go
@@ -1,0 +1,52 @@
+package paths
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/storage/mgmt/storage"
+	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/datalakestore/filesystems"
+	"github.com/tombuildsstuff/giovanni/testhelpers"
+)
+
+func TestLifecycle(t *testing.T) {
+	client, err := testhelpers.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.TODO()
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	fileSystemName := fmt.Sprintf("acctestfs-%s", testhelpers.RandomString())
+	path := "test"
+
+	if _, err = client.BuildTestResourcesWithHns(ctx, resourceGroup, accountName, storage.BlobStorage); err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+	fileSystemsClient := filesystems.NewWithEnvironment(client.Environment)
+	fileSystemsClient.Client = client.PrepareWithStorageResourceManagerAuth(fileSystemsClient.Client)
+	pathsClient := NewWithEnvironment(client.Environment)
+	pathsClient.Client = client.PrepareWithStorageResourceManagerAuth(fileSystemsClient.Client)
+
+	t.Logf("[DEBUG] Creating an empty File System..")
+	fileSystemInput := filesystems.CreateInput{}
+	if _, err = fileSystemsClient.Create(ctx, accountName, fileSystemName, fileSystemInput); err != nil {
+		t.Fatal(fmt.Errorf("Error creating: %s", err))
+	}
+
+	t.Logf("[DEBUG] Creating folder 'test' ..")
+	input := CreateInput{
+		Resource: PathResourceDirectory,
+	}
+	if _, err = pathsClient.Create(ctx, accountName, fileSystemName, path, input); err != nil {
+		t.Fatal(fmt.Errorf("Error creating: %s", err))
+	}
+
+	t.Logf("[DEBUG] Deleting File System..")
+	if _, err := fileSystemsClient.Delete(ctx, accountName, fileSystemName); err != nil {
+		t.Fatalf("Error deleting: %s", err)
+	}
+}

--- a/storage/2018-11-09/datalakestore/paths/lifecycle_test.go
+++ b/storage/2018-11-09/datalakestore/paths/lifecycle_test.go
@@ -49,7 +49,7 @@ func TestLifecycle(t *testing.T) {
 	}
 
 	t.Logf("[DEBUG] Getting properties for folder 'test' ..")
-	props, err := pathsClient.GetProperties(ctx, accountName, fileSystemName, path)
+	props, err := pathsClient.GetProperties(ctx, accountName, fileSystemName, path, GetPropertiesActionGetAccessControl)
 	if err != nil {
 		t.Fatal(fmt.Errorf("Error getting properties: %s", err))
 	}
@@ -72,7 +72,7 @@ func TestLifecycle(t *testing.T) {
 	}
 
 	t.Logf("[DEBUG] Getting properties for folder 'test' (2) ..")
-	props, err = pathsClient.GetProperties(ctx, accountName, fileSystemName, path)
+	props, err = pathsClient.GetProperties(ctx, accountName, fileSystemName, path, GetPropertiesActionGetAccessControl)
 	if err != nil {
 		t.Fatal(fmt.Errorf("Error getting properties (2): %s", err))
 	}

--- a/storage/2018-11-09/datalakestore/paths/properties_get.go
+++ b/storage/2018-11-09/datalakestore/paths/properties_get.go
@@ -1,0 +1,106 @@
+package paths
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+type GetPropertiesResponse struct {
+	autorest.Response
+
+	ResourceType PathResource
+}
+
+// GetProperties gets the properties for a Data Lake Store Gen2 Path in a FileSystem within a Storage Account
+func (client Client) GetProperties(ctx context.Context, accountName string, fileSystemName string, path string) (result GetPropertiesResponse, err error) {
+	if accountName == "" {
+		return result, validation.NewError("datalakestore.Client", "GetProperties", "`accountName` cannot be an empty string.")
+	}
+	if fileSystemName == "" {
+		return result, validation.NewError("datalakestore.Client", "GetProperties", "`fileSystemName` cannot be an empty string.")
+	}
+
+	req, err := client.GetPropertiesPreparer(ctx, accountName, fileSystemName, path)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "GetProperties", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.GetPropertiesSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "GetProperties", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.GetPropertiesResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "GetProperties", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// GetPropertiesPreparer prepares the GetProperties request.
+func (client Client) GetPropertiesPreparer(ctx context.Context, accountName string, fileSystemName string, path string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"fileSystemName": autorest.Encode("path", fileSystemName),
+		"path":           autorest.Encode("path", path),
+	}
+
+	queryParameters := map[string]interface{}{
+		// "action": autorest.Encode("query", "getAccessControl"),
+		"action": autorest.Encode("query", "getStatus"),
+	}
+
+	headers := map[string]interface{}{
+		"x-ms-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsHead(),
+		autorest.WithBaseURL(endpoints.GetDataLakeStoreEndpoint(client.BaseURI, accountName)),
+		autorest.WithPathParameters("/{fileSystemName}/{path}", pathParameters),
+		autorest.WithQueryParameters(queryParameters),
+		autorest.WithHeaders(headers))
+
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// GetPropertiesSender sends the GetProperties request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) GetPropertiesSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// GetPropertiesResponder handles the response to the GetProperties request. The method always
+// closes the http.Response Body.
+func (client Client) GetPropertiesResponder(resp *http.Response) (result GetPropertiesResponse, err error) {
+	if resp != nil && resp.Header != nil {
+		resourceTypeRaw := resp.Header.Get("x-ms-resource-type")
+		var resourceType PathResource
+		if resourceTypeRaw != "" {
+			resourceType, err = parsePathResource(resourceTypeRaw)
+			if err != nil {
+				return
+			}
+			result.ResourceType = resourceType
+		}
+	}
+	log.Printf("*****: %v\n", resp)
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+
+	return
+}

--- a/storage/2018-11-09/datalakestore/paths/properties_set.go
+++ b/storage/2018-11-09/datalakestore/paths/properties_set.go
@@ -1,0 +1,116 @@
+package paths
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+type SetAccessControlInput struct {
+	Owner *string
+	Group *string
+	ACL   *string
+
+	// Optional - A date and time value.
+	// Specify this header to perform the operation only if the resource has been modified since the specified date and time.
+	IfModifiedSince *string
+
+	// Optional - A date and time value.
+	// Specify this header to perform the operation only if the resource has not been modified since the specified date and time.
+	IfUnmodifiedSince *string
+}
+
+// SetProperties sets the access control properties for a Data Lake Store Gen2 Path within a Storage Account File System
+func (client Client) SetAccessControl(ctx context.Context, accountName string, fileSystemName string, path string, input SetAccessControlInput) (result autorest.Response, err error) {
+	if accountName == "" {
+		return result, validation.NewError("datalakestore.Client", "SetAccessControl", "`accountName` cannot be an empty string.")
+	}
+	if fileSystemName == "" {
+		return result, validation.NewError("datalakestore.Client", "SetAccessControl", "`fileSystemName` cannot be an empty string.")
+	}
+
+	req, err := client.SetAccessControlPreparer(ctx, accountName, fileSystemName, path, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "SetAccessControl", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.SetAccessControlSender(req)
+	if err != nil {
+		result = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "SetAccessControl", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.SetAccessControlResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "datalakestore.Client", "SetAccessControl", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// SetAccessControlPreparer prepares the SetAccessControl request.
+func (client Client) SetAccessControlPreparer(ctx context.Context, accountName string, fileSystemName string, path string, input SetAccessControlInput) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"fileSystemName": autorest.Encode("path", fileSystemName),
+		"path":           autorest.Encode("path", path),
+	}
+
+	queryParameters := map[string]interface{}{
+		"action": autorest.Encode("query", "setAccessControl"),
+	}
+
+	headers := map[string]interface{}{
+		"x-ms-version": APIVersion,
+	}
+
+	if input.Owner != nil {
+		headers["x-ms-owner"] = *input.Owner
+	}
+	if input.Group != nil {
+		headers["x-ms-group"] = *input.Group
+	}
+	if input.ACL != nil {
+		headers["x-ms-acl"] = *input.ACL
+	}
+
+	if input.IfModifiedSince != nil {
+		headers["If-Modified-Since"] = *input.IfModifiedSince
+	}
+	if input.IfUnmodifiedSince != nil {
+		headers["If-Unmodified-Since"] = *input.IfUnmodifiedSince
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsPatch(),
+		autorest.WithBaseURL(endpoints.GetDataLakeStoreEndpoint(client.BaseURI, accountName)),
+		autorest.WithPathParameters("/{fileSystemName}/{path}", pathParameters),
+		autorest.WithQueryParameters(queryParameters),
+		autorest.WithHeaders(headers))
+
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// SetAccessControlSender sends the SetAccessControl request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) SetAccessControlSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// SetAccessControlResponder handles the response to the SetAccessControl request. The method always
+// closes the http.Response Body.
+func (client Client) SetAccessControlResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+	result = autorest.Response{Response: resp}
+	return
+}

--- a/storage/2018-11-09/datalakestore/paths/resource_id.go
+++ b/storage/2018-11-09/datalakestore/paths/resource_id.go
@@ -1,0 +1,57 @@
+package paths
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+// GetResourceID returns the Resource ID for the given Data Lake Storage FileSystem
+// This can be useful when, for example, you're using this as a unique identifier
+func (client Client) GetResourceID(accountName, fileSystemName, path string) string {
+	domain := endpoints.GetDataLakeStoreEndpoint(client.BaseURI, accountName)
+	return fmt.Sprintf("%s/%s/%s", domain, fileSystemName, path)
+}
+
+type ResourceID struct {
+	AccountName    string
+	FileSystemName string
+	Path           string
+}
+
+// ParseResourceID parses the specified Resource ID and returns an object
+// which can be used to interact with the Data Lake Storage FileSystem API's
+func ParseResourceID(id string) (*ResourceID, error) {
+	// example: https://foo.dfs.core.windows.net/Bar
+	if id == "" {
+		return nil, fmt.Errorf("`id` was empty")
+	}
+
+	uri, err := url.Parse(id)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing ID as a URL: %s", err)
+	}
+
+	accountName, err := endpoints.GetAccountNameFromEndpoint(uri.Host)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing Account Name: %s", err)
+	}
+
+	fileSystemAndPath := strings.TrimPrefix(uri.Path, "/")
+	separatorIndex := strings.Index(fileSystemAndPath, "/")
+	var fileSystem, path string
+	if separatorIndex < 0 {
+		fileSystem = fileSystemAndPath
+		path = ""
+	} else {
+		fileSystem = fileSystemAndPath[0:separatorIndex]
+		path = fileSystemAndPath[separatorIndex+1:]
+	}
+	return &ResourceID{
+		AccountName:    *accountName,
+		FileSystemName: fileSystem,
+		Path:           path,
+	}, nil
+}

--- a/storage/2018-11-09/datalakestore/paths/resource_id_test.go
+++ b/storage/2018-11-09/datalakestore/paths/resource_id_test.go
@@ -1,0 +1,90 @@
+package paths
+
+import (
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+func TestGetResourceID(t *testing.T) {
+	testData := []struct {
+		AccountName    string
+		FileSystemName string
+		Path           string
+		Expected       string
+	}{
+		{
+			AccountName:    "account1",
+			FileSystemName: "fs1",
+			Path:           "test",
+			Expected:       "https://account1.dfs.core.windows.net/fs1/test",
+		},
+		{
+			AccountName:    "account1",
+			FileSystemName: "fs1",
+			Path:           "test/test2",
+			Expected:       "https://account1.dfs.core.windows.net/fs1/test/test2",
+		},
+		{
+			AccountName:    "account1",
+			FileSystemName: "fs1",
+			Path:           "",
+			Expected:       "https://account1.dfs.core.windows.net/fs1/",
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing Path %q", v.Path)
+		c := NewWithEnvironment(azure.PublicCloud)
+		actual := c.GetResourceID(v.AccountName, v.FileSystemName, v.Path)
+		if actual != v.Expected {
+			t.Fatalf("Expected the Resource ID to be %q but got %q", v.Expected, actual)
+		}
+	}
+}
+
+func TestParseResourceID(t *testing.T) {
+	testData := []struct {
+		Input          string
+		AccountName    string
+		FileSystemName string
+		Path           string
+	}{
+		{
+			Input:          "https://account1.dfs.core.windows.net/fs1/test",
+			AccountName:    "account1",
+			FileSystemName: "fs1",
+			Path:           "test",
+		},
+		{
+			Input:          "https://account1.dfs.core.windows.net/fs1/test/test2",
+			AccountName:    "account1",
+			FileSystemName: "fs1",
+			Path:           "test/test2",
+		},
+		{
+			Input:          "https://account1.dfs.core.windows.net/fs1/",
+			AccountName:    "account1",
+			FileSystemName: "fs1",
+			Path:           "",
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing Path %q", v.Path)
+		actual, err := ParseResourceID(v.Input)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if actual.AccountName != v.AccountName {
+			t.Fatalf("Expected the account name to be `%q` but got %q", v.AccountName, actual.AccountName)
+		}
+
+		if actual.FileSystemName != v.FileSystemName {
+			t.Fatalf("Expected the file system name to be `%q` but got %q", v.FileSystemName, actual.FileSystemName)
+		}
+
+		if actual.Path != v.Path {
+			t.Fatalf("Expected the path to be `%q` but got %q", v.Path, actual.Path)
+		}
+	}
+}

--- a/storage/2018-11-09/datalakestore/paths/version.go
+++ b/storage/2018-11-09/datalakestore/paths/version.go
@@ -1,0 +1,14 @@
+package paths
+
+import (
+	"fmt"
+
+	"github.com/tombuildsstuff/giovanni/version"
+)
+
+// APIVersion is the version of the API used for all Storage API Operations
+const APIVersion = "2018-11-09"
+
+func UserAgent() string {
+	return fmt.Sprintf("tombuildsstuff/giovanni/%s storage/%s", version.Number, APIVersion)
+}

--- a/storage/accesscontrol/ace.go
+++ b/storage/accesscontrol/ace.go
@@ -1,0 +1,123 @@
+package accesscontrol
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+type TagType string
+
+const (
+	TagTypeUser  TagType = "user"
+	TagTypeGroup TagType = "group"
+	TagTypeMask  TagType = "mask"
+	TagTypeOther TagType = "other"
+)
+
+// ACE is roughly modelled on https://linux.die.net/man/5/acl
+// Have collapsed ACL_USER_OBJ to be TagType of user with a nil Qualifier
+
+type ACE struct {
+	IsDefault    bool
+	TagType      TagType
+	TagQualifier *uuid.UUID
+	Permissions  string // TODO break the rwx into permission flags?
+}
+
+var permissionsRegex *regexp.Regexp
+
+func init() {
+	permissionsRegex = regexp.MustCompile("[r-][w-][x-]")
+}
+
+// ValidateACEPermissions checks the format of the ACE permission string. Returns nil on success.
+func ValidateACEPermissions(permissions string) error {
+	if !permissionsRegex.MatchString(permissions) {
+		return fmt.Errorf("Permissions must be of the form [r-][w-][x-]")
+	}
+	return nil
+}
+
+// Validate checks the formatting and combination of values in the ACE. Returns nil on success
+func (ace *ACE) Validate() error {
+	switch ace.TagType {
+	case TagTypeMask, TagTypeOther:
+		if ace.TagQualifier != nil {
+			return fmt.Errorf("TagQualifier cannot be set for 'mask' or 'other' TagTypes")
+		}
+	}
+
+	if err := ValidateACEPermissions(ace.Permissions); err != nil {
+		return err
+	}
+
+	if err := validateTagType(ace.TagType); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ParseACE parses an ACE string and returns the ACE
+func ParseACE(input string) (ACE, error) {
+	ace := ACE{}
+
+	parts := strings.Split(input, ":")
+	if len(parts) == 4 {
+		if parts[0] == "default" {
+			ace.IsDefault = true
+			parts = parts[1:]
+		} else {
+			return ACE{}, fmt.Errorf("When specifying a 4-part ACE the first part must be 'default'")
+		}
+	}
+
+	if len(parts) != 3 {
+		return ACE{}, fmt.Errorf("ACE string should have either 3 or 4 parts")
+	}
+
+	ace.TagType = TagType(parts[0])
+
+	qualiferString := parts[1]
+	if qualiferString != "" {
+		qualifier, err := uuid.Parse(qualiferString)
+		if err != nil {
+			return ACE{}, fmt.Errorf("Error parsing qualifer %q: %s", qualiferString, err)
+		}
+		ace.TagQualifier = &qualifier
+	}
+
+	ace.Permissions = parts[2]
+
+	if err := ace.Validate(); err != nil {
+		return ACE{}, err
+	}
+	return ace, nil
+}
+
+// String returns the string form of the ACE - this does not check that it is valid
+func (ace *ACE) String() string {
+	prefix := ""
+	if ace.IsDefault {
+		prefix = "default:"
+	}
+	qualifierString := ""
+	if ace.TagQualifier != nil {
+		qualifierString = ace.TagQualifier.String()
+	}
+	return fmt.Sprintf("%s%s:%s:%s", prefix, ace.TagType, qualifierString, ace.Permissions)
+}
+
+func validateTagType(tagType TagType) error {
+	switch tagType {
+	case TagTypeUser,
+		TagTypeGroup,
+		TagTypeMask,
+		TagTypeOther:
+		return nil
+	}
+	return fmt.Errorf("Unrecognized TagType: %q", tagType)
+}

--- a/storage/accesscontrol/ace_test.go
+++ b/storage/accesscontrol/ace_test.go
@@ -1,0 +1,91 @@
+package accesscontrol
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestACEValidate_WithValidACE(t *testing.T) {
+	ace := ACE{
+		TagType:     TagTypeUser,
+		Permissions: "rwx",
+	}
+	assert.Nil(t, ace.Validate(), "Expected ACE to Validate successfully")
+}
+
+func TestACEValidate_WithACEInvalidPermisions(t *testing.T) {
+	ace := ACE{
+		TagType:     TagTypeUser,
+		Permissions: "awx",
+	}
+
+	assert.EqualError(t, ace.Validate(), "Permissions must be of the form [r-][w-][x-]")
+}
+
+func TestACEValidate_WithACEQualifierSetForMask(t *testing.T) {
+	qualifier := uuid.MustParse("ba4662cb-995c-479d-8f7c-a1b3d8ae05a9")
+	ace := ACE{
+		TagType:      TagTypeMask,
+		TagQualifier: &qualifier,
+		Permissions:  "rwx",
+	}
+
+	assert.EqualError(t, ace.Validate(), "TagQualifier cannot be set for 'mask' or 'other' TagTypes")
+}
+
+func TestACEParse_WithValidDefault(t *testing.T) {
+	ace, err := ParseACE("default:user:22edd3d8-9253-4463-b8f8-442ebe33b622:rwx")
+	assert.NoError(t, err)
+	assert.Equal(t, true, ace.IsDefault, "Expected default")
+	assert.Equal(t, TagTypeUser, ace.TagType)
+	assert.Equal(t, "22edd3d8-9253-4463-b8f8-442ebe33b622", ace.TagQualifier.String())
+	assert.Equal(t, "rwx", ace.Permissions)
+}
+func TestACEParse_WithValidNonDefault(t *testing.T) {
+	ace, err := ParseACE("user:885d0d94-9ecb-4e0d-8581-781b56d27b10:rwx")
+	assert.NoError(t, err)
+	assert.Equal(t, false, ace.IsDefault, "Expected non-default")
+	assert.Equal(t, TagTypeUser, ace.TagType)
+	assert.Equal(t, "885d0d94-9ecb-4e0d-8581-781b56d27b10", ace.TagQualifier.String())
+	assert.Equal(t, "rwx", ace.Permissions)
+}
+
+func TestACEParse_WithInvalid4Part(t *testing.T) {
+	_, err := ParseACE("test:::")
+	assert.EqualError(t, err, "When specifying a 4-part ACE the first part must be 'default'")
+}
+func TestACEParse_WithInvalidTagType(t *testing.T) {
+	_, err := ParseACE("wibble::rwx")
+	assert.EqualError(t, err, "Unrecognized TagType: \"wibble\"")
+}
+func TestACEParse_WithInvalidNumberOfParts(t *testing.T) {
+	_, err := ParseACE("user:rwx")
+	assert.EqualError(t, err, "ACE string should have either 3 or 4 parts")
+}
+func TestACEParse_WithInvalidQualifier(t *testing.T) {
+	_, err := ParseACE("user:wibble94-9ecb-4e0d-8581-781b56d27b10:rwx")
+	assert.EqualError(t, err, "Error parsing qualifer \"wibble94-9ecb-4e0d-8581-781b56d27b10\": invalid UUID format")
+}
+
+func TestACEString_WithDefault(t *testing.T) {
+	qualifier := uuid.MustParse("ba4662cb-995c-479d-8f7c-a1b3d8ae05a9")
+	ace := ACE{
+		IsDefault:    true,
+		TagType:      TagTypeUser,
+		TagQualifier: &qualifier,
+		Permissions:  "r-x",
+	}
+	assert.Equal(t, "default:user:ba4662cb-995c-479d-8f7c-a1b3d8ae05a9:r-x", ace.String())
+}
+func TestACEString_WithNonDefault(t *testing.T) {
+	qualifier := uuid.MustParse("ba4662cb-995c-479d-8f7c-a1b3d8ae05a9")
+	ace := ACE{
+		IsDefault:    false,
+		TagType:      TagTypeGroup,
+		TagQualifier: &qualifier,
+		Permissions:  "rw-",
+	}
+	assert.Equal(t, "group:ba4662cb-995c-479d-8f7c-a1b3d8ae05a9:rw-", ace.String())
+}

--- a/storage/accesscontrol/acl.go
+++ b/storage/accesscontrol/acl.go
@@ -1,0 +1,53 @@
+package accesscontrol
+
+import (
+	"strings"
+)
+
+type ACL struct {
+	Entries []ACE
+}
+
+// Validate checks the ACL. Returns nil on success
+func (acl *ACL) Validate() error {
+
+	// TODO
+	//   - check each user/group is only listed once (per default/non-default)
+
+	for _, v := range acl.Entries {
+		if err := v.Validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ParseACL parses an ACL string
+func ParseACL(input string) (ACL, error) {
+
+	aceStrings := strings.Split(input, ",")
+	entries := make([]ACE, len(aceStrings))
+
+	for i := 0; i < len(aceStrings); i++ {
+		aceString := aceStrings[i]
+		entry, err := ParseACE(aceString)
+		if err != nil {
+			return ACL{}, err
+		}
+		entries[i] = entry
+	}
+	return ACL{Entries: entries}, nil
+}
+
+// String returns the string form of the ACL - this does not check that it is valid
+func (acl *ACL) String() string {
+
+	aceStrings := make([]string, len(acl.Entries))
+
+	for i := 0; i < len(acl.Entries); i++ {
+		ace := acl.Entries[i]
+		aceStrings[i] = ace.String()
+	}
+	return strings.Join(aceStrings, ",")
+}

--- a/storage/accesscontrol/acl_test.go
+++ b/storage/accesscontrol/acl_test.go
@@ -1,0 +1,94 @@
+package accesscontrol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestACLValidate_WithValidACL(t *testing.T) {
+	acl := ACL{
+		Entries: []ACE{
+			{
+				TagType:     TagTypeUser,
+				Permissions: "rwx",
+			},
+			{
+				TagType:     TagTypeGroup,
+				Permissions: "r-x",
+			},
+			{
+				TagType:     TagTypeOther,
+				Permissions: "---",
+			},
+		},
+	}
+	assert.Nil(t, acl.Validate(), "Expected ACE to Validate successfully")
+}
+
+func TestACLValidate_WithInvalidACL(t *testing.T) {
+	acl := ACL{
+		Entries: []ACE{
+			{
+				TagType:     TagType("wibble"),
+				Permissions: "rwx",
+			},
+			{
+				TagType:     TagTypeGroup,
+				Permissions: "r-x",
+			},
+			{
+				TagType:     TagTypeOther,
+				Permissions: "---",
+			},
+		},
+	}
+	assert.Error(t, acl.Validate(), "Expected ACE to fail to Validate")
+}
+
+func TestACLString(t *testing.T) {
+	acl := ACL{
+		Entries: []ACE{
+			{
+				TagType:     TagTypeUser,
+				Permissions: "rwx",
+			},
+			{
+				TagType:     TagTypeGroup,
+				Permissions: "r-x",
+			},
+			{
+				TagType:     TagTypeOther,
+				Permissions: "---",
+			},
+		},
+	}
+	assert.Equal(t, "user::rwx,group::r-x,other::---", acl.String())
+}
+
+func TestACLParse_WithValidACL(t *testing.T) {
+	expected := ACL{
+		Entries: []ACE{
+			{
+				TagType:     TagTypeUser,
+				Permissions: "rwx",
+			},
+			{
+				TagType:     TagTypeGroup,
+				Permissions: "r-x",
+			},
+			{
+				TagType:     TagTypeOther,
+				Permissions: "---",
+			},
+		},
+	}
+	acl, err := ParseACL("user::rwx,group::r-x,other::---")
+	assert.Nil(t, err, "Expected ACE to parse successfully")
+	assert.Equal(t, expected, acl)
+}
+
+func TestACLParse_WithInvalidACL(t *testing.T) {
+	_, err := ParseACL("user:rwx,group::r-x,other::---")
+	assert.EqualError(t, err, "ACE string should have either 3 or 4 parts")
+}

--- a/testhelpers/client.go
+++ b/testhelpers/client.go
@@ -33,6 +33,12 @@ type TestResources struct {
 }
 
 func (client Client) BuildTestResources(ctx context.Context, resourceGroup, name string, kind storage.Kind) (*TestResources, error) {
+	return client.buildTestResources(ctx, resourceGroup, name, kind, false)
+}
+func (client Client) BuildTestResourcesWithHns(ctx context.Context, resourceGroup, name string, kind storage.Kind) (*TestResources, error) {
+	return client.buildTestResources(ctx, resourceGroup, name, kind, true)
+}
+func (client Client) buildTestResources(ctx context.Context, resourceGroup, name string, kind storage.Kind, enableHns bool) (*TestResources, error) {
 	location := toPointeredString(os.Getenv("ARM_TEST_LOCATION"))
 	_, err := client.ResourceGroupsClient.CreateOrUpdate(ctx, resourceGroup, resources.Group{
 		Location: location,
@@ -45,6 +51,10 @@ func (client Client) BuildTestResources(ctx context.Context, resourceGroup, name
 	if kind == storage.BlobStorage {
 		props.AccessTier = storage.Hot
 	}
+	if enableHns {
+		props.IsHnsEnabled = &enableHns
+	}
+
 	future, err := client.StorageClient.Create(ctx, resourceGroup, name, storage.AccountCreateParameters{
 		Location: location,
 		Sku: &storage.Sku{


### PR DESCRIPTION
Initial implementation of [Path API](https://docs.microsoft.com/en-gb/rest/api/storageservices/datalakestoragegen2/path) (for directory creation) to support https://github.com/terraform-providers/terraform-provider-azurerm/issues/7118