### PR TITLE
Fix ADLS Path Deletion

### DIFF
--- a/storage/2018-11-09/datalakestore/paths/delete.go
+++ b/storage/2018-11-09/datalakestore/paths/delete.go
@@ -73,7 +73,7 @@ func (client Client) DeleteResponder(resp *http.Response) (result autorest.Respo
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
-		azure.WithErrorUnlessStatusCode(http.StatusAccepted),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByClosing())
 	result = autorest.Response{Response: resp}
 

--- a/storage/2018-11-09/datalakestore/paths/lifecycle_test.go
+++ b/storage/2018-11-09/datalakestore/paths/lifecycle_test.go
@@ -85,6 +85,12 @@ func TestLifecycle(t *testing.T) {
 		t.Fatal(fmt.Errorf("Error deleting path: %s", err))
 	}
 
+	t.Logf("[DEBUG] Getting properties for folder 'test' (3) ..")
+	props, err = pathsClient.GetProperties(ctx, accountName, fileSystemName, path, GetPropertiesActionGetAccessControl)
+	if err == nil {
+		t.Fatal(fmt.Errorf("Didn't get error getting properties after deleting path (3)"))
+	}
+
 	t.Logf("[DEBUG] Deleting File System..")
 	if _, err := fileSystemsClient.Delete(ctx, accountName, fileSystemName); err != nil {
 		t.Fatalf("Error deleting filesystem: %s", err)

--- a/storage/2018-11-09/datalakestore/paths/lifecycle_test.go
+++ b/storage/2018-11-09/datalakestore/paths/lifecycle_test.go
@@ -80,8 +80,13 @@ func TestLifecycle(t *testing.T) {
 		t.Fatal(fmt.Errorf("Expected new ACL %q, got %q", newACL, props.ACL))
 	}
 
+	t.Logf("[DEBUG] Deleting path 'test' ..")
+	if _, err = pathsClient.Delete(ctx, accountName, fileSystemName, path); err != nil {
+		t.Fatal(fmt.Errorf("Error deleting path: %s", err))
+	}
+
 	t.Logf("[DEBUG] Deleting File System..")
 	if _, err := fileSystemsClient.Delete(ctx, accountName, fileSystemName); err != nil {
-		t.Fatalf("Error deleting: %s", err)
+		t.Fatalf("Error deleting filesystem: %s", err)
 	}
 }

--- a/storage/2018-11-09/datalakestore/paths/properties_get.go
+++ b/storage/2018-11-09/datalakestore/paths/properties_get.go
@@ -130,5 +130,5 @@ func (client Client) GetPropertiesResponder(resp *http.Response) (result GetProp
 		autorest.ByClosing())
 	result.Response = autorest.Response{Response: resp}
 
-	return result, nil
+	return result, err
 }


### PR DESCRIPTION
* Add path deletion step to ADLS path lifecycle test
* Fix `DeleteResponder` to expect StatusOK (`200`) as per [the docs](https://docs.microsoft.com/en-gb/rest/api/storageservices/datalakestoragegen2/path/delete#response)
* Add a check that a non-existent path returns an error from `GetProperties`
* Fix `GetProperties` to return the API response error

Fixes #32