### PR TITLE
2019-12-12/files/file - update properties set attributes

### DIFF
--- a/storage/2019-12-12/file/files/lifecycle_test.go
+++ b/storage/2019-12-12/file/files/lifecycle_test.go
@@ -75,7 +75,10 @@ func TestFilesLifeCycle(t *testing.T) {
 	updatedEncoding := "application/vnd+pandas2"
 	updatedInput := SetPropertiesInput{
 		ContentEncoding: &updatedEncoding,
-		ContentLength:   &updatedSize,
+		ContentLength:   updatedSize,
+		MetaData: map[string]string{
+			"bingo": "bango",
+		},
 	}
 	t.Logf("[DEBUG] Setting Properties for the Top-Level File..")
 	if _, err := filesClient.SetProperties(ctx, accountName, shareName, "", fileName, updatedInput); err != nil {
@@ -94,6 +97,13 @@ func TestFilesLifeCycle(t *testing.T) {
 
 	if file.ContentEncoding != updatedEncoding {
 		t.Fatalf("Expected the Content-Encoding to be %q but got %q", updatedEncoding, file.ContentEncoding)
+	}
+
+	if len(file.MetaData) != 1 {
+		t.Fatalf("Expected 1 item but got %d", len(file.MetaData))
+	}
+	if file.MetaData["bingo"] != "bango" {
+		t.Fatalf("Expected `bingo` to be `bango` but got %q", file.MetaData["bingo"])
 	}
 
 	t.Logf("[DEBUG] Setting MetaData..")


### PR DESCRIPTION
This PR allows setting metadata in the properties set function and fixes an issue where a required header was missing when content-length wasn't specified. 