### PR TITLE
fix for terraform-providers/terraform-provider-azurerm#10888

### DIFF
--- a/storage/2019-12-12/file/files/properties_get.go
+++ b/storage/2019-12-12/file/files/properties_get.go
@@ -111,7 +111,7 @@ func (client Client) GetPropertiesResponder(resp *http.Response) (result GetResu
 		result.ContentDisposition = resp.Header.Get("Content-Disposition")
 		result.ContentEncoding = resp.Header.Get("Content-Encoding")
 		result.ContentLanguage = resp.Header.Get("Content-Language")
-		result.ContentMD5 = resp.Header.Get("x-ms-content-md5")
+		result.ContentMD5 = resp.Header.Get("Content-MD5")
 		result.ContentType = resp.Header.Get("Content-Type")
 		result.CopyID = resp.Header.Get("x-ms-copy-id")
 		result.CopyProgress = resp.Header.Get("x-ms-copy-progress")


### PR DESCRIPTION
Hi! This is to address issue terraform-providers/terraform-provider-azurerm#10888. Pasting my comment here from the [issue tracker](https://github.com/terraform-providers/terraform-provider-azurerm/issues/10888#issuecomment-847565100):

> Hi. I looked a little into this and it seems that the return of GetProperties call in [storage_share_file_resource.go](https://github.com/terraform-providers/terraform-provider-azurerm/blob/2b30abb96725abae3c38e846bf1d8a1e2b0fcf2d/azurerm/internal/services/storage/storage_share_file_resource.go#L289) has an empty `ContentMD5`. I looked further in the Microsoft doc[1] and the function call in Giovanni storage SDK [2]. Giovanni uses response header `x-ms-content-md5` and according to the Microsoft doc, the `Range` or `x-ms-range` header must be set for this response header to be returned:
> 
> ```
> Starting from version 2016-05-31, if the file has a MD5 hash, and if  request contains range header (Range or x-ms-range), this response  header is returned with the value of the whole file’s MD5 value. This  value may or may not be equal to the value returned in Content-MD5  header, with the latter calculated from the requested range.
> ```
> 
> I tested this by replacing `x-ms-content-md5` with `Content-MD5` in this [file](https://github.com/terraform-providers/terraform-provider-azurerm/blob/2b30abb96725abae3c38e846bf1d8a1e2b0fcf2d/vendor/github.com/tombuildsstuff/giovanni/storage/2019-12-12/file/files/properties_get.go#L114) in the giovanni package under the vendor folder. I was able to retrieve the value. Since giovanni is not passing any range header anyway, is this a valid fix? Should this be raised as PR in this repo or in giovanni repo?
> 
> References:
> [1] https://docs.microsoft.com/en-us/rest/api/storageservices/get-file
> [2] https://github.com/tombuildsstuff/giovanni/blob/9de4e973cdac0d3f7b512b4afaed66393d3c608c/storage/2019-12-12/file/files/properties_get.go#L114

