### PR TITLE
Table exists API add api version and accept json

### DIFF
--- a/storage/2020-08-04/table/tables/exists.go
+++ b/storage/2020-08-04/table/tables/exists.go
@@ -47,15 +47,21 @@ func (client Client) ExistsPreparer(ctx context.Context, accountName, tableName 
 		"tableName": autorest.Encode("path", tableName),
 	}
 
+	headers := map[string]interface{}{
+		"x-ms-version": APIVersion,
+		"Accept":       "application/json;odata=nometadata",
+	}
+
 	// NOTE: whilst the API documentation says that API Version is Optional
 	// apparently specifying it causes an "invalid content type" to always be returned
 	// as such we omit it here :shrug:
 
 	preparer := autorest.CreatePreparer(
 		autorest.AsGet(),
-		autorest.AsContentType("application/xml"),
+		autorest.AsContentType("application/json"),
 		autorest.WithBaseURL(endpoints.GetTableEndpoint(client.BaseURI, accountName)),
-		autorest.WithPathParameters("/Tables('{tableName}')", pathParameters))
+		autorest.WithPathParameters("/Tables('{tableName}')", pathParameters),
+		autorest.WithHeaders(headers))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
 


### PR DESCRIPTION
1. API version is necessary here to make the API accepts the AAD Auth
2. The Accept json header is necessary here since otherwise the returned
   xml is in atom format, in which case the autorest will fail to parse.

This PR is related with hashicorp/terraform-provider-azurerm#15083