### PR TITLE
storage queue: xml encoding omity empty for retention policy `days`

### DIFF
--- a/storage/2017-07-29/queue/queues/models.go
+++ b/storage/2017-07-29/queue/queues/models.go
@@ -26,7 +26,7 @@ type MetricsConfig struct {
 
 type RetentionPolicy struct {
 	Enabled bool `xml:"Enabled"`
-	Days    int  `xml:"Days"`
+	Days    int  `xml:"Days,omitempty"`
 }
 
 type Cors struct {

--- a/storage/2018-03-28/queue/queues/models.go
+++ b/storage/2018-03-28/queue/queues/models.go
@@ -26,7 +26,7 @@ type MetricsConfig struct {
 
 type RetentionPolicy struct {
 	Enabled bool `xml:"Enabled"`
-	Days    int  `xml:"Days"`
+	Days    int  `xml:"Days,omitempty"`
 }
 
 type Cors struct {

--- a/storage/2018-11-09/queue/queues/models.go
+++ b/storage/2018-11-09/queue/queues/models.go
@@ -26,7 +26,7 @@ type MetricsConfig struct {
 
 type RetentionPolicy struct {
 	Enabled bool `xml:"Enabled"`
-	Days    int  `xml:"Days"`
+	Days    int  `xml:"Days,omitempty"`
 }
 
 type Cors struct {

--- a/storage/2019-12-12/queue/queues/models.go
+++ b/storage/2019-12-12/queue/queues/models.go
@@ -26,7 +26,7 @@ type MetricsConfig struct {
 
 type RetentionPolicy struct {
 	Enabled bool `xml:"Enabled"`
-	Days    int  `xml:"Days"`
+	Days    int  `xml:"Days,omitempty"`
 }
 
 type Cors struct {

--- a/storage/2020-08-04/queue/queues/models.go
+++ b/storage/2020-08-04/queue/queues/models.go
@@ -26,7 +26,7 @@ type MetricsConfig struct {
 
 type RetentionPolicy struct {
 	Enabled bool `xml:"Enabled"`
-	Days    int  `xml:"Days"`
+	Days    int  `xml:"Days,omitempty"`
 }
 
 type Cors struct {


### PR DESCRIPTION
The retention policy days is not allowed to be set when retention policy is disabled.

E.g. when sending following request:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<StorageServiceProperties>
   <Logging>
      <Version>1.0</Version>
      <Delete>false</Delete>
      <Read>false</Read>
      <Write>false</Write>
      <RetentionPolicy>
         <Enabled>false</Enabled>
         <Days>7</Days>
      </RetentionPolicy>
   </Logging>
   <HourMetrics>
      <Version>1.0</Version>
      <Enabled>false</Enabled>
      <RetentionPolicy>
         <Enabled>false</Enabled>
         <Days>7</Days>
      </RetentionPolicy>
   </HourMetrics>
   <MinuteMetrics>
      <Version>1.0</Version>
      <Enabled>false</Enabled>
      <RetentionPolicy>
         <Enabled>true</Enabled>
         <Days>7</Days>
      </RetentionPolicy>
   </MinuteMetrics>
   <Cors />
</StorageServiceProperties>
```

The API returns:

```
﻿<?xml version="1.0" encoding="utf-8"?><Error><Code>InvalidXmlDocument</Code><Message>XML specified is not syntactically valid.
RequestId:acae5f1e-0003-003d-7fe8-59e5e1000000
Time:2022-04-27T03:43:10.0593681Z</Message><LineNumber>1</LineNumber><LinePosition>213</LinePosition><Reason>Element Days is only expected when RetentionPolicy is enabled.</Reason></Error>
```