### PR TITLE
`files.(Client).PutFile`: return error when Put an empty file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 .idea/
 example/example
 .DS_Store
+.vscode/

--- a/storage/2020-08-04/file/files/range_put_file.go
+++ b/storage/2020-08-04/file/files/range_put_file.go
@@ -17,6 +17,10 @@ func (c Client) PutFile(ctx context.Context, shareName, path, fileName string, f
 		return fmt.Errorf("error loading file info: %s", err)
 	}
 
+	if fileInfo.Size() == 0 {
+		return fmt.Errorf("file is empty which is not supported")
+	}
+
 	fileSize := fileInfo.Size()
 	chunkSize := 4 * 1024 * 1024 // 4MB
 	if chunkSize > int(fileSize) {


### PR DESCRIPTION
Fixes: #93.
