### PR TITLE
Fixups for 2023-11-03 SDK

### DIFF
--- a/storage/2020-08-04/queue/queues/models.go
+++ b/storage/2020-08-04/queue/queues/models.go
@@ -36,7 +36,7 @@ type Cors struct {
 type CorsRule struct {
 	AllowedOrigins  string `xml:"AllowedOrigins"`
 	AllowedMethods  string `xml:"AllowedMethods"`
-	AllowedHeaders  string `xml:"AllowedHeaders`
+	AllowedHeaders  string `xml:"AllowedHeaders"`
 	ExposedHeaders  string `xml:"ExposedHeaders"`
 	MaxAgeInSeconds int    `xml:"MaxAgeInSeconds"`
 }

--- a/storage/2023-11-03/blob/accounts/set_service_properties.go
+++ b/storage/2023-11-03/blob/accounts/set_service_properties.go
@@ -9,12 +9,12 @@ import (
 )
 
 type SetServicePropertiesResult struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
-func (c Client) SetServiceProperties(ctx context.Context, accountName string, input StorageServiceProperties) (resp SetServicePropertiesResult, err error) {
+func (c Client) SetServiceProperties(ctx context.Context, accountName string, input StorageServiceProperties) (result SetServicePropertiesResult, err error) {
 	if accountName == "" {
-		return resp, fmt.Errorf("`accountName` cannot be an empty string")
+		return result, fmt.Errorf("`accountName` cannot be an empty string")
 	}
 
 	opts := client.RequestOptions{
@@ -26,16 +26,23 @@ func (c Client) SetServiceProperties(ctx context.Context, accountName string, in
 		OptionsObject: servicePropertiesOptions{},
 		Path:          "/",
 	}
+
 	req, err := c.Client.NewRequest(ctx, opts)
 	if err != nil {
 		err = fmt.Errorf("building request: %+v", err)
 		return
 	}
+
 	if err = req.Marshal(&input); err != nil {
 		err = fmt.Errorf("marshaling request: %+v", err)
 		return
 	}
-	resp.HttpResponse, err = req.Execute(ctx)
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/blob/accounts/set_service_properties_test.go
+++ b/storage/2023-11-03/blob/accounts/set_service_properties_test.go
@@ -79,12 +79,12 @@ func TestContainerLifecycle(t *testing.T) {
 		t.Fatal(fmt.Errorf("error getting properties: %s", err))
 	}
 
-	website := result.Model.StaticWebsite
+	website := result.StaticWebsite
 	if website.Enabled != true {
 		t.Fatalf("Expected the StaticWebsite %t but got %t", true, website.Enabled)
 	}
 
-	logging := result.Model.Logging
+	logging := result.Logging
 	if logging.Version != "2.0" {
 		t.Fatalf("Expected the Logging Version %s but got %s", "2.0", logging.Version)
 	}

--- a/storage/2023-11-03/blob/blobs/README.md
+++ b/storage/2023-11-03/blob/blobs/README.md
@@ -30,7 +30,7 @@ func Example() error {
 
 	blobClient, err := blobs.NewWithBaseUri(fmt.Sprintf("https://%s.blob.%s", accountName, domainSuffix))
 	if err != nil {
-		return fmt.Errorf("building client for environment: %+v", err)
+		return fmt.Errorf("building client for environment: %v", err)
 	}
 	
 	auth, err := auth.NewSharedKeyAuthorizer(accountName, storageAccountKey, auth.SharedKey)

--- a/storage/2023-11-03/blob/blobs/blob_page_test.go
+++ b/storage/2023-11-03/blob/blobs/blob_page_test.go
@@ -42,7 +42,7 @@ func TestPageBlobLifecycle(t *testing.T) {
 		t.Fatalf("building client for environment: %+v", err)
 	}
 
-	if err := client.PrepareWithSharedKeyAuth(containersClient.Client, testData, auth.SharedKey); err != nil {
+	if err = client.PrepareWithSharedKeyAuth(containersClient.Client, testData, auth.SharedKey); err != nil {
 		t.Fatalf("adding authorizer to client: %+v", err)
 	}
 
@@ -57,7 +57,7 @@ func TestPageBlobLifecycle(t *testing.T) {
 		t.Fatalf("building client for environment: %+v", err)
 	}
 
-	if err := client.PrepareWithSharedKeyAuth(blobClient.Client, testData, auth.SharedKey); err != nil {
+	if err = client.PrepareWithSharedKeyAuth(blobClient.Client, testData, auth.SharedKey); err != nil {
 		t.Fatalf("adding authorizer to client: %+v", err)
 	}
 

--- a/storage/2023-11-03/blob/blobs/copy_abort.go
+++ b/storage/2023-11-03/blob/blobs/copy_abort.go
@@ -20,26 +20,29 @@ type AbortCopyInput struct {
 }
 
 type CopyAbortResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // AbortCopy aborts a pending Copy Blob operation, and leaves a destination blob with zero length and full metadata.
-func (c Client) AbortCopy(ctx context.Context, containerName, blobName string, input AbortCopyInput) (resp CopyAbortResponse, err error) {
-
+func (c Client) AbortCopy(ctx context.Context, containerName, blobName string, input AbortCopyInput) (result CopyAbortResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(containerName) != containerName {
-		return resp, fmt.Errorf("`containerName` must be a lower-cased string")
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
 	}
 
 	if blobName == "" {
-		return resp, fmt.Errorf("`blobName` cannot be an empty string")
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
 	}
 
 	if input.CopyID == "" {
-		return resp, fmt.Errorf("`input.CopyID` cannot be an empty string")
+		err = fmt.Errorf("`input.CopyID` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -59,7 +62,11 @@ func (c Client) AbortCopy(ctx context.Context, containerName, blobName string, i
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/blob/blobs/copy_test.go
+++ b/storage/2023-11-03/blob/blobs/copy_test.go
@@ -43,7 +43,7 @@ func TestCopyFromExistingFile(t *testing.T) {
 		t.Fatalf("building client for environment: %+v", err)
 	}
 
-	if err := client.PrepareWithSharedKeyAuth(containersClient.Client, testData, auth.SharedKey); err != nil {
+	if err = client.PrepareWithSharedKeyAuth(containersClient.Client, testData, auth.SharedKey); err != nil {
 		t.Fatalf("adding authorizer to client: %+v", err)
 	}
 
@@ -59,7 +59,7 @@ func TestCopyFromExistingFile(t *testing.T) {
 		t.Fatalf("building client for environment: %+v", err)
 	}
 
-	if err := client.PrepareWithSharedKeyAuth(blobClient.Client, testData, auth.SharedKey); err != nil {
+	if err = client.PrepareWithSharedKeyAuth(blobClient.Client, testData, auth.SharedKey); err != nil {
 		t.Fatalf("adding authorizer to client: %+v", err)
 	}
 
@@ -137,7 +137,7 @@ func TestCopyFromURL(t *testing.T) {
 		t.Fatalf("building client for environment: %+v", err)
 	}
 
-	if err := client.PrepareWithSharedKeyAuth(containersClient.Client, testData, auth.SharedKey); err != nil {
+	if err = client.PrepareWithSharedKeyAuth(containersClient.Client, testData, auth.SharedKey); err != nil {
 		t.Fatalf("adding authorizer to client: %+v", err)
 	}
 
@@ -152,7 +152,7 @@ func TestCopyFromURL(t *testing.T) {
 		t.Fatalf("building client for environment: %+v", err)
 	}
 
-	if err := client.PrepareWithSharedKeyAuth(blobClient.Client, testData, auth.SharedKey); err != nil {
+	if err = client.PrepareWithSharedKeyAuth(blobClient.Client, testData, auth.SharedKey); err != nil {
 		t.Fatalf("adding authorizer to client: %+v", err)
 	}
 

--- a/storage/2023-11-03/blob/blobs/delete.go
+++ b/storage/2023-11-03/blob/blobs/delete.go
@@ -21,22 +21,21 @@ type DeleteInput struct {
 }
 
 type DeleteResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Delete marks the specified blob or snapshot for deletion. The blob is later deleted during garbage collection.
-func (c Client) Delete(ctx context.Context, containerName, blobName string, input DeleteInput) (resp DeleteResponse, err error) {
-
+func (c Client) Delete(ctx context.Context, containerName, blobName string, input DeleteInput) (result DeleteResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		return result, fmt.Errorf("`containerName` cannot be an empty string")
 	}
 
 	if strings.ToLower(containerName) != containerName {
-		return resp, fmt.Errorf("`containerName` must be a lower-cased string")
+		return result, fmt.Errorf("`containerName` must be a lower-cased string")
 	}
 
 	if blobName == "" {
-		return resp, fmt.Errorf("`blobName` cannot be an empty string")
+		return result, fmt.Errorf("`blobName` cannot be an empty string")
 	}
 
 	opts := client.RequestOptions{
@@ -56,7 +55,11 @@ func (c Client) Delete(ctx context.Context, containerName, blobName string, inpu
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/blob/blobs/delete_snapshot.go
+++ b/storage/2023-11-03/blob/blobs/delete_snapshot.go
@@ -20,26 +20,29 @@ type DeleteSnapshotInput struct {
 }
 
 type DeleteSnapshotResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // DeleteSnapshot marks a single Snapshot of a Blob for Deletion based on it's DateTime, which will be deleted during the next Garbage Collection cycle.
-func (c Client) DeleteSnapshot(ctx context.Context, containerName, blobName string, input DeleteSnapshotInput) (resp DeleteSnapshotResponse, err error) {
-
+func (c Client) DeleteSnapshot(ctx context.Context, containerName, blobName string, input DeleteSnapshotInput) (result DeleteSnapshotResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(containerName) != containerName {
-		return resp, fmt.Errorf("`containerName` must be a lower-cased string")
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
 	}
 
 	if blobName == "" {
-		return resp, fmt.Errorf("`blobName` cannot be an empty string")
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
 	}
 
 	if input.SnapshotDateTime == "" {
-		return resp, fmt.Errorf("`input.SnapshotDateTime` cannot be an empty string")
+		err = fmt.Errorf("`input.SnapshotDateTime` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -59,7 +62,11 @@ func (c Client) DeleteSnapshot(ctx context.Context, containerName, blobName stri
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/blob/blobs/delete_snapshots.go
+++ b/storage/2023-11-03/blob/blobs/delete_snapshots.go
@@ -17,22 +17,24 @@ type DeleteSnapshotsInput struct {
 }
 
 type DeleteSnapshotsResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // DeleteSnapshots marks all Snapshots of a Blob for Deletion, which will be deleted during the next Garbage Collection Cycle.
-func (c Client) DeleteSnapshots(ctx context.Context, containerName, blobName string, input DeleteSnapshotsInput) (resp DeleteSnapshotsResponse, err error) {
-
+func (c Client) DeleteSnapshots(ctx context.Context, containerName, blobName string, input DeleteSnapshotsInput) (result DeleteSnapshotsResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(containerName) != containerName {
-		return resp, fmt.Errorf("`containerName` must be a lower-cased string")
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
 	}
 
 	if blobName == "" {
-		return resp, fmt.Errorf("`blobName` cannot be an empty string")
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -52,7 +54,11 @@ func (c Client) DeleteSnapshots(ctx context.Context, containerName, blobName str
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/blob/blobs/get_page_ranges.go
+++ b/storage/2023-11-03/blob/blobs/get_page_ranges.go
@@ -19,7 +19,7 @@ type GetPageRangesInput struct {
 }
 
 type GetPageRangesResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 
 	// The size of the blob in bytes
 	ContentLength *int64
@@ -42,22 +42,21 @@ type PageRange struct {
 }
 
 // GetPageRanges returns the list of valid page ranges for a page blob or snapshot of a page blob.
-func (c Client) GetPageRanges(ctx context.Context, containerName, blobName string, input GetPageRangesInput) (resp GetPageRangesResponse, err error) {
-
+func (c Client) GetPageRanges(ctx context.Context, containerName, blobName string, input GetPageRangesInput) (result GetPageRangesResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		return result, fmt.Errorf("`containerName` cannot be an empty string")
 	}
 
 	if strings.ToLower(containerName) != containerName {
-		return resp, fmt.Errorf("`containerName` must be a lower-cased string")
+		return result, fmt.Errorf("`containerName` must be a lower-cased string")
 	}
 
 	if blobName == "" {
-		return resp, fmt.Errorf("`blobName` cannot be an empty string")
+		return result, fmt.Errorf("`blobName` cannot be an empty string")
 	}
 
-	if (input.StartByte != nil && input.EndByte == nil) || input.StartByte == nil && input.EndByte != nil {
-		return resp, fmt.Errorf("`input.StartByte` and `input.EndByte` must both be specified, or both be nil")
+	if (input.StartByte != nil && input.EndByte == nil) || (input.StartByte == nil && input.EndByte != nil) {
+		return result, fmt.Errorf("`input.StartByte` and `input.EndByte` must both be specified, or both be nil")
 	}
 
 	opts := client.RequestOptions{
@@ -77,33 +76,36 @@ func (c Client) GetPageRanges(ctx context.Context, containerName, blobName strin
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
-	if err != nil {
-		err = fmt.Errorf("executing request: %+v", err)
-		return
-	}
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
 
-	if resp.HttpResponse != nil {
-		if resp.HttpResponse.Header != nil {
-			resp.ContentType = resp.HttpResponse.Header.Get("Content-Type")
-			resp.ETag = resp.HttpResponse.Header.Get("ETag")
+		if resp.Header != nil {
+			result.ContentType = resp.Header.Get("Content-Type")
+			result.ETag = resp.Header.Get("ETag")
 
-			if v := resp.HttpResponse.Header.Get("x-ms-blob-content-length"); v != "" {
+			if v := resp.Header.Get("x-ms-blob-content-length"); v != "" {
 				i, innerErr := strconv.Atoi(v)
 				if innerErr != nil {
-					err = fmt.Errorf("Error parsing %q as an integer: %s", v, innerErr)
+					err = fmt.Errorf("parsing `x-ms-blob-content-length` header value %q: %+v", v, innerErr)
 					return
 				}
 
 				i64 := int64(i)
-				resp.ContentLength = &i64
+				result.ContentLength = &i64
 			}
 		}
 
-		err = resp.HttpResponse.Unmarshal(&resp)
+		err = resp.Unmarshal(&result)
 		if err != nil {
-			return resp, fmt.Errorf("unmarshalling response: %s", err)
+			err = fmt.Errorf("unmarshalling response: %+v", err)
+			return
 		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
 	}
 
 	return

--- a/storage/2023-11-03/blob/blobs/incremental_copy_blob.go
+++ b/storage/2023-11-03/blob/blobs/incremental_copy_blob.go
@@ -19,29 +19,32 @@ type IncrementalCopyBlobInput struct {
 }
 
 type IncrementalCopyBlob struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // IncrementalCopyBlob copies a snapshot of the source page blob to a destination page blob.
 // The snapshot is copied such that only the differential changes between the previously copied
 // snapshot are transferred to the destination.
 // The copied snapshots are complete copies of the original snapshot and can be read or copied from as usual.
-func (c Client) IncrementalCopyBlob(ctx context.Context, containerName, blobName string, input IncrementalCopyBlobInput) (resp IncrementalCopyBlob, err error) {
-
+func (c Client) IncrementalCopyBlob(ctx context.Context, containerName, blobName string, input IncrementalCopyBlobInput) (result IncrementalCopyBlob, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(containerName) != containerName {
-		return resp, fmt.Errorf("`containerName` must be a lower-cased string")
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
 	}
 
 	if blobName == "" {
-		return resp, fmt.Errorf("`blobName` cannot be an empty string")
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
 	}
 
 	if input.CopySource == "" {
-		return resp, fmt.Errorf("`input.CopySource` cannot be an empty string")
+		err = fmt.Errorf("`input.CopySource` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -61,7 +64,11 @@ func (c Client) IncrementalCopyBlob(ctx context.Context, containerName, blobName
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/blob/blobs/lease_acquire.go
+++ b/storage/2023-11-03/blob/blobs/lease_acquire.go
@@ -24,36 +24,41 @@ type AcquireLeaseInput struct {
 }
 
 type AcquireLeaseResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 
 	LeaseID string
 }
 
 // AcquireLease establishes and manages a lock on a blob for write and delete operations.
-func (c Client) AcquireLease(ctx context.Context, containerName, blobName string, input AcquireLeaseInput) (resp AcquireLeaseResponse, err error) {
-
+func (c Client) AcquireLease(ctx context.Context, containerName, blobName string, input AcquireLeaseInput) (result AcquireLeaseResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(containerName) != containerName {
-		return resp, fmt.Errorf("`containerName` must be a lower-cased string")
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
 	}
 
 	if blobName == "" {
-		return resp, fmt.Errorf("`blobName` cannot be an empty string")
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
 	}
 
 	if input.LeaseID != nil && *input.LeaseID == "" {
-		return resp, fmt.Errorf("`input.LeaseID` cannot be an empty string, if specified")
+		err = fmt.Errorf("`input.LeaseID` cannot be an empty string, if specified")
+		return
 	}
 
 	if input.ProposedLeaseID != nil && *input.ProposedLeaseID == "" {
-		return resp, fmt.Errorf("`input.ProposedLeaseID` cannot be an empty string, if specified")
+		err = fmt.Errorf("`input.ProposedLeaseID` cannot be an empty string, if specified")
+		return
 	}
 	// An infinite lease duration is -1 seconds. A non-infinite lease can be between 15 and 60 seconds
 	if input.LeaseDuration != -1 && (input.LeaseDuration <= 15 || input.LeaseDuration >= 60) {
-		return resp, fmt.Errorf("`input.LeaseDuration` must be -1 (infinite), or between 15 and 60 seconds")
+		err = fmt.Errorf("`input.LeaseDuration` must be -1 (infinite), or between 15 and 60 seconds")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -73,16 +78,18 @@ func (c Client) AcquireLease(ctx context.Context, containerName, blobName string
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+
+		if resp.Header != nil {
+			result.LeaseID = resp.Header.Get("x-ms-lease-id")
+		}
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return
-	}
-
-	if resp.HttpResponse != nil {
-		if resp.HttpResponse.Header != nil {
-			resp.LeaseID = resp.HttpResponse.Header.Get("x-ms-lease-id")
-		}
 	}
 
 	return

--- a/storage/2023-11-03/blob/blobs/lease_release.go
+++ b/storage/2023-11-03/blob/blobs/lease_release.go
@@ -11,7 +11,7 @@ import (
 )
 
 type ReleaseLeaseResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 type ReleaseLeaseInput struct {
@@ -19,22 +19,25 @@ type ReleaseLeaseInput struct {
 }
 
 // ReleaseLease releases a lock based on the Lease ID.
-func (c Client) ReleaseLease(ctx context.Context, containerName, blobName string, input ReleaseLeaseInput) (resp ReleaseLeaseResponse, err error) {
-
+func (c Client) ReleaseLease(ctx context.Context, containerName, blobName string, input ReleaseLeaseInput) (result ReleaseLeaseResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(containerName) != containerName {
-		return resp, fmt.Errorf("`containerName` must be a lower-cased string")
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
 	}
 
 	if blobName == "" {
-		return resp, fmt.Errorf("`blobName` cannot be an empty string")
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
 	}
 
 	if input.LeaseID == "" {
-		return resp, fmt.Errorf("`input.LeaseID` cannot be an empty string")
+		err = fmt.Errorf("`input.LeaseID` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -54,7 +57,11 @@ func (c Client) ReleaseLease(ctx context.Context, containerName, blobName string
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/blob/blobs/lease_renew.go
+++ b/storage/2023-11-03/blob/blobs/lease_renew.go
@@ -11,29 +11,32 @@ import (
 )
 
 type RenewLeaseResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 type RenewLeaseInput struct {
 	LeaseID string
 }
 
-func (c Client) RenewLease(ctx context.Context, containerName, blobName string, input RenewLeaseInput) (resp RenewLeaseResponse, err error) {
-
+func (c Client) RenewLease(ctx context.Context, containerName, blobName string, input RenewLeaseInput) (result RenewLeaseResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(containerName) != containerName {
-		return resp, fmt.Errorf("`containerName` must be a lower-cased string")
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
 	}
 
 	if blobName == "" {
-		return resp, fmt.Errorf("`blobName` cannot be an empty string")
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
 	}
 
 	if input.LeaseID == "" {
-		return resp, fmt.Errorf("`input.LeaseID` cannot be an empty string")
+		err = fmt.Errorf("`input.LeaseID` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -53,7 +56,11 @@ func (c Client) RenewLease(ctx context.Context, containerName, blobName string, 
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/blob/blobs/lease_test.go
+++ b/storage/2023-11-03/blob/blobs/lease_test.go
@@ -42,7 +42,7 @@ func TestLeaseLifecycle(t *testing.T) {
 		t.Fatalf("building client for environment: %+v", err)
 	}
 
-	if err := client.PrepareWithSharedKeyAuth(containersClient.Client, testData, auth.SharedKey); err != nil {
+	if err = client.PrepareWithSharedKeyAuth(containersClient.Client, testData, auth.SharedKey); err != nil {
 		t.Fatalf("adding authorizer to client: %+v", err)
 	}
 
@@ -57,7 +57,7 @@ func TestLeaseLifecycle(t *testing.T) {
 		t.Fatalf("building client for environment: %+v", err)
 	}
 
-	if err := client.PrepareWithSharedKeyAuth(blobClient.Client, testData, auth.SharedKey); err != nil {
+	if err = client.PrepareWithSharedKeyAuth(blobClient.Client, testData, auth.SharedKey); err != nil {
 		t.Fatalf("adding authorizer to client: %+v", err)
 	}
 

--- a/storage/2023-11-03/blob/blobs/lifecycle_test.go
+++ b/storage/2023-11-03/blob/blobs/lifecycle_test.go
@@ -44,7 +44,7 @@ func TestLifecycle(t *testing.T) {
 		t.Fatalf("building client for environment: %+v", err)
 	}
 
-	if err := client.PrepareWithSharedKeyAuth(containersClient.Client, testData, auth.SharedKey); err != nil {
+	if err = client.PrepareWithSharedKeyAuth(containersClient.Client, testData, auth.SharedKey); err != nil {
 		t.Fatalf("adding authorizer to client: %+v", err)
 	}
 
@@ -59,7 +59,7 @@ func TestLifecycle(t *testing.T) {
 		t.Fatalf("building client for environment: %+v", err)
 	}
 
-	if err := client.PrepareWithSharedKeyAuth(blobClient.Client, testData, auth.SharedKey); err != nil {
+	if err = client.PrepareWithSharedKeyAuth(blobClient.Client, testData, auth.SharedKey); err != nil {
 		t.Fatalf("adding authorizer to client: %+v", err)
 	}
 

--- a/storage/2023-11-03/blob/blobs/metadata_set.go
+++ b/storage/2023-11-03/blob/blobs/metadata_set.go
@@ -21,26 +21,29 @@ type SetMetaDataInput struct {
 }
 
 type SetMetaDataResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // SetMetaData marks the specified blob or snapshot for deletion. The blob is later deleted during garbage collection.
-func (c Client) SetMetaData(ctx context.Context, containerName, blobName string, input SetMetaDataInput) (resp SetMetaDataResponse, err error) {
-
+func (c Client) SetMetaData(ctx context.Context, containerName, blobName string, input SetMetaDataInput) (result SetMetaDataResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(containerName) != containerName {
-		return resp, fmt.Errorf("`containerName` must be a lower-cased string")
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
 	}
 
 	if blobName == "" {
-		return resp, fmt.Errorf("`blobName` cannot be an empty string")
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
 	}
 
-	if err := metadata.Validate(input.MetaData); err != nil {
-		return resp, fmt.Errorf(fmt.Sprintf("`input.MetaData` is not valid: %s.", err))
+	if err = metadata.Validate(input.MetaData); err != nil {
+		err = fmt.Errorf(fmt.Sprintf("`input.MetaData` is not valid: %s.", err))
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -60,7 +63,11 @@ func (c Client) SetMetaData(ctx context.Context, containerName, blobName string,
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/blob/blobs/properties_get.go
+++ b/storage/2023-11-03/blob/blobs/properties_get.go
@@ -3,13 +3,13 @@ package blobs
 import (
 	"context"
 	"fmt"
-	"github.com/tombuildsstuff/giovanni/storage/internal/metadata"
 	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/client"
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/tombuildsstuff/giovanni/storage/internal/metadata"
 )
 
 type GetPropertiesInput struct {
@@ -228,7 +228,7 @@ func (c Client) GetProperties(ctx context.Context, containerName, blobName strin
 			if v := resp.Header.Get("x-ms-access-tier-inferred"); v != "" {
 				b, innerErr := strconv.ParseBool(v)
 				if innerErr != nil {
-					err = fmt.Errorf("error parsing %q as a bool: %s", v, innerErr)
+					err = fmt.Errorf("parsing `x-ms-access-tier-inferred` header value %q: %s", v, innerErr)
 					return
 				}
 				result.AccessTierInferred = b
@@ -237,7 +237,7 @@ func (c Client) GetProperties(ctx context.Context, containerName, blobName strin
 			if v := resp.Header.Get("Content-Length"); v != "" {
 				i, innerErr := strconv.Atoi(v)
 				if innerErr != nil {
-					err = fmt.Errorf("error parsing %q as an integer: %s", v, innerErr)
+					err = fmt.Errorf("parsing `Content-Length` header value %q: %s", v, innerErr)
 				}
 				result.ContentLength = int64(i)
 			}
@@ -245,7 +245,7 @@ func (c Client) GetProperties(ctx context.Context, containerName, blobName strin
 			if v := resp.Header.Get("x-ms-incremental-copy"); v != "" {
 				b, innerErr := strconv.ParseBool(v)
 				if innerErr != nil {
-					err = fmt.Errorf("error parsing %q as a bool: %s", v, innerErr)
+					err = fmt.Errorf("parsing `x-ms-incremental-copy` header value %q: %s", v, innerErr)
 					return
 				}
 				result.IncrementalCopy = b
@@ -254,7 +254,7 @@ func (c Client) GetProperties(ctx context.Context, containerName, blobName strin
 			if v := resp.Header.Get("x-ms-server-encrypted"); v != "" {
 				b, innerErr := strconv.ParseBool(v)
 				if innerErr != nil {
-					err = fmt.Errorf("error parsing %q as a bool: %s", v, innerErr)
+					err = fmt.Errorf("parsing `x-ms-server-encrypted` header value %q: %s", v, innerErr)
 					return
 				}
 				result.ServerEncrypted = b

--- a/storage/2023-11-03/blob/blobs/properties_get.go
+++ b/storage/2023-11-03/blob/blobs/properties_get.go
@@ -3,13 +3,13 @@ package blobs
 import (
 	"context"
 	"fmt"
+	"github.com/tombuildsstuff/giovanni/storage/internal/metadata"
 	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/client"
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
-	"github.com/tombuildsstuff/giovanni/storage/internal/metadata"
 )
 
 type GetPropertiesInput struct {
@@ -19,7 +19,7 @@ type GetPropertiesInput struct {
 }
 
 type GetPropertiesResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 
 	// The tier of page blob on a premium storage account or tier of block blob on blob storage or general purpose v2 account.
 	AccessTier AccessTier
@@ -161,16 +161,18 @@ type GetPropertiesResponse struct {
 }
 
 // GetProperties returns all user-defined metadata, standard HTTP properties, and system properties for the blob
-func (c Client) GetProperties(ctx context.Context, containerName, blobName string, input GetPropertiesInput) (resp GetPropertiesResponse, err error) {
-
+func (c Client) GetProperties(ctx context.Context, containerName, blobName string, input GetPropertiesInput) (result GetPropertiesResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
 	}
 	if strings.ToLower(containerName) != containerName {
-		return resp, fmt.Errorf("`containerName` must be a lower-cased string")
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
 	}
 	if blobName == "" {
-		return resp, fmt.Errorf("`blobName` cannot be an empty string")
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -190,76 +192,78 @@ func (c Client) GetProperties(ctx context.Context, containerName, blobName strin
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
-	if err != nil {
-		err = fmt.Errorf("executing request: %+v", err)
-		return
-	}
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
 
-	if resp.HttpResponse != nil {
-		if resp.HttpResponse.Header != nil {
-			resp.AccessTier = AccessTier(resp.HttpResponse.Header.Get("x-ms-access-tier"))
-			resp.AccessTierChangeTime = resp.HttpResponse.Header.Get("x-ms-access-tier-change-time")
-			resp.ArchiveStatus = ArchiveStatus(resp.HttpResponse.Header.Get("x-ms-archive-status"))
-			resp.BlobCommittedBlockCount = resp.HttpResponse.Header.Get("x-ms-blob-committed-block-count")
-			resp.BlobSequenceNumber = resp.HttpResponse.Header.Get("x-ms-blob-sequence-number")
-			resp.BlobType = BlobType(resp.HttpResponse.Header.Get("x-ms-blob-type"))
-			resp.CacheControl = resp.HttpResponse.Header.Get("Cache-Control")
-			resp.ContentDisposition = resp.HttpResponse.Header.Get("Content-Disposition")
-			resp.ContentEncoding = resp.HttpResponse.Header.Get("Content-Encoding")
-			resp.ContentLanguage = resp.HttpResponse.Header.Get("Content-Language")
-			resp.ContentMD5 = resp.HttpResponse.Header.Get("Content-MD5")
-			resp.ContentType = resp.HttpResponse.Header.Get("Content-Type")
-			resp.CopyCompletionTime = resp.HttpResponse.Header.Get("x-ms-copy-completion-time")
-			resp.CopyDestinationSnapshot = resp.HttpResponse.Header.Get("x-ms-copy-destination-snapshot")
-			resp.CopyID = resp.HttpResponse.Header.Get("x-ms-copy-id")
-			resp.CopyProgress = resp.HttpResponse.Header.Get("x-ms-copy-progress")
-			resp.CopySource = resp.HttpResponse.Header.Get("x-ms-copy-source")
-			resp.CopyStatus = CopyStatus(resp.HttpResponse.Header.Get("x-ms-copy-status"))
-			resp.CopyStatusDescription = resp.HttpResponse.Header.Get("x-ms-copy-status-description")
-			resp.CreationTime = resp.HttpResponse.Header.Get("x-ms-creation-time")
-			resp.ETag = resp.HttpResponse.Header.Get("Etag")
-			resp.LastModified = resp.HttpResponse.Header.Get("Last-Modified")
-			resp.LeaseDuration = LeaseDuration(resp.HttpResponse.Header.Get("x-ms-lease-duration"))
-			resp.LeaseState = LeaseState(resp.HttpResponse.Header.Get("x-ms-lease-state"))
-			resp.LeaseStatus = LeaseStatus(resp.HttpResponse.Header.Get("x-ms-lease-status"))
-			resp.MetaData = metadata.ParseFromHeaders(resp.HttpResponse.Header)
+		if resp.Header != nil {
+			result.AccessTier = AccessTier(resp.Header.Get("x-ms-access-tier"))
+			result.AccessTierChangeTime = resp.Header.Get("x-ms-access-tier-change-time")
+			result.ArchiveStatus = ArchiveStatus(resp.Header.Get("x-ms-archive-status"))
+			result.BlobCommittedBlockCount = resp.Header.Get("x-ms-blob-committed-block-count")
+			result.BlobSequenceNumber = resp.Header.Get("x-ms-blob-sequence-number")
+			result.BlobType = BlobType(resp.Header.Get("x-ms-blob-type"))
+			result.CacheControl = resp.Header.Get("Cache-Control")
+			result.ContentDisposition = resp.Header.Get("Content-Disposition")
+			result.ContentEncoding = resp.Header.Get("Content-Encoding")
+			result.ContentLanguage = resp.Header.Get("Content-Language")
+			result.ContentMD5 = resp.Header.Get("Content-MD5")
+			result.ContentType = resp.Header.Get("Content-Type")
+			result.CopyCompletionTime = resp.Header.Get("x-ms-copy-completion-time")
+			result.CopyDestinationSnapshot = resp.Header.Get("x-ms-copy-destination-snapshot")
+			result.CopyID = resp.Header.Get("x-ms-copy-id")
+			result.CopyProgress = resp.Header.Get("x-ms-copy-progress")
+			result.CopySource = resp.Header.Get("x-ms-copy-source")
+			result.CopyStatus = CopyStatus(resp.Header.Get("x-ms-copy-status"))
+			result.CopyStatusDescription = resp.Header.Get("x-ms-copy-status-description")
+			result.CreationTime = resp.Header.Get("x-ms-creation-time")
+			result.ETag = resp.Header.Get("Etag")
+			result.LastModified = resp.Header.Get("Last-Modified")
+			result.LeaseDuration = LeaseDuration(resp.Header.Get("x-ms-lease-duration"))
+			result.LeaseState = LeaseState(resp.Header.Get("x-ms-lease-state"))
+			result.LeaseStatus = LeaseStatus(resp.Header.Get("x-ms-lease-status"))
+			result.MetaData = metadata.ParseFromHeaders(resp.Header)
 
-			if v := resp.HttpResponse.Header.Get("x-ms-access-tier-inferred"); v != "" {
+			if v := resp.Header.Get("x-ms-access-tier-inferred"); v != "" {
 				b, innerErr := strconv.ParseBool(v)
 				if innerErr != nil {
 					err = fmt.Errorf("error parsing %q as a bool: %s", v, innerErr)
 					return
 				}
-				resp.AccessTierInferred = b
+				result.AccessTierInferred = b
 			}
 
-			if v := resp.HttpResponse.Header.Get("Content-Length"); v != "" {
+			if v := resp.Header.Get("Content-Length"); v != "" {
 				i, innerErr := strconv.Atoi(v)
 				if innerErr != nil {
 					err = fmt.Errorf("error parsing %q as an integer: %s", v, innerErr)
 				}
-				resp.ContentLength = int64(i)
+				result.ContentLength = int64(i)
 			}
 
-			if v := resp.HttpResponse.Header.Get("x-ms-incremental-copy"); v != "" {
+			if v := resp.Header.Get("x-ms-incremental-copy"); v != "" {
 				b, innerErr := strconv.ParseBool(v)
 				if innerErr != nil {
 					err = fmt.Errorf("error parsing %q as a bool: %s", v, innerErr)
 					return
 				}
-				resp.IncrementalCopy = b
+				result.IncrementalCopy = b
 			}
 
-			if v := resp.HttpResponse.Header.Get("x-ms-server-encrypted"); v != "" {
+			if v := resp.Header.Get("x-ms-server-encrypted"); v != "" {
 				b, innerErr := strconv.ParseBool(v)
 				if innerErr != nil {
 					err = fmt.Errorf("error parsing %q as a bool: %s", v, innerErr)
 					return
 				}
-				resp.ServerEncrypted = b
+				result.ServerEncrypted = b
 			}
 		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
 	}
 
 	return

--- a/storage/2023-11-03/blob/blobs/properties_set.go
+++ b/storage/2023-11-03/blob/blobs/properties_set.go
@@ -25,25 +25,24 @@ type SetPropertiesInput struct {
 }
 
 type SetPropertiesResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 
 	BlobSequenceNumber string
 	Etag               string
 }
 
 // SetProperties sets system properties on the blob.
-func (c Client) SetProperties(ctx context.Context, containerName, blobName string, input SetPropertiesInput) (resp SetPropertiesResponse, err error) {
-
+func (c Client) SetProperties(ctx context.Context, containerName, blobName string, input SetPropertiesInput) (result SetPropertiesResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		return result, fmt.Errorf("`containerName` cannot be an empty string")
 	}
 
 	if strings.ToLower(containerName) != containerName {
-		return resp, fmt.Errorf("`containerName` must be a lower-cased string")
+		return result, fmt.Errorf("`containerName` must be a lower-cased string")
 	}
 
 	if blobName == "" {
-		return resp, fmt.Errorf("`blobName` cannot be an empty string")
+		return result, fmt.Errorf("`blobName` cannot be an empty string")
 	}
 
 	opts := client.RequestOptions{
@@ -63,7 +62,11 @@ func (c Client) SetProperties(ctx context.Context, containerName, blobName strin
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/blob/blobs/put_block.go
+++ b/storage/2023-11-03/blob/blobs/put_block.go
@@ -19,32 +19,36 @@ type PutBlockInput struct {
 }
 
 type PutBlockResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 
 	ContentMD5 string
 }
 
 // PutBlock creates a new block to be committed as part of a blob.
-func (c Client) PutBlock(ctx context.Context, containerName, blobName string, input PutBlockInput) (resp PutBlockResponse, err error) {
-
+func (c Client) PutBlock(ctx context.Context, containerName, blobName string, input PutBlockInput) (result PutBlockResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(containerName) != containerName {
-		return resp, fmt.Errorf("`containerName` must be a lower-cased string")
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
 	}
 
 	if blobName == "" {
-		return resp, fmt.Errorf("`blobName` cannot be an empty string")
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
 	}
 
 	if input.BlockID == "" {
-		return resp, fmt.Errorf("`input.BlockID` cannot be an empty string")
+		err = fmt.Errorf("`input.BlockID` cannot be an empty string")
+		return
 	}
 
 	if len(input.Content) == 0 {
-		return resp, fmt.Errorf("`input.Content` cannot be empty")
+		err = fmt.Errorf("`input.Content` cannot be empty")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -66,10 +70,15 @@ func (c Client) PutBlock(ctx context.Context, containerName, blobName string, in
 
 	err = req.Marshal(&input.Content)
 	if err != nil {
-		return resp, fmt.Errorf("marshalling request: %v", err)
+		err = fmt.Errorf("marshalling request: %+v", err)
+		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/blob/blobs/put_block_blob_file.go
+++ b/storage/2023-11-03/blob/blobs/put_block_blob_file.go
@@ -11,7 +11,7 @@ import (
 func (c Client) PutBlockBlobFromFile(ctx context.Context, containerName, blobName string, file *os.File, input PutBlockBlobInput) error {
 	fileInfo, err := file.Stat()
 	if err != nil {
-		return fmt.Errorf("error loading file info: %s", err)
+		return fmt.Errorf("loading file info: %s", err)
 	}
 
 	fileSize := fileInfo.Size()
@@ -20,14 +20,14 @@ func (c Client) PutBlockBlobFromFile(ctx context.Context, containerName, blobNam
 	_, err = file.ReadAt(bytes, 0)
 	if err != nil {
 		if err != io.EOF {
-			return fmt.Errorf("Error reading bytes: %s", err)
+			return fmt.Errorf("reading bytes: %s", err)
 		}
 	}
 
 	input.Content = &bytes
 
 	if _, err = c.PutBlockBlob(ctx, containerName, blobName, input); err != nil {
-		return fmt.Errorf("error putting bytes: %s", err)
+		return fmt.Errorf("putting bytes: %s", err)
 	}
 
 	return nil

--- a/storage/2023-11-03/blob/blobs/put_page_clear.go
+++ b/storage/2023-11-03/blob/blobs/put_page_clear.go
@@ -18,30 +18,34 @@ type PutPageClearInput struct {
 }
 
 type PutPageClearResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // PutPageClear clears a range of pages within a page blob.
-func (c Client) PutPageClear(ctx context.Context, containerName, blobName string, input PutPageClearInput) (resp PutPageClearResponse, err error) {
-
+func (c Client) PutPageClear(ctx context.Context, containerName, blobName string, input PutPageClearInput) (result PutPageClearResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(containerName) != containerName {
-		return resp, fmt.Errorf("`containerName` must be a lower-cased string")
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
 	}
 
 	if blobName == "" {
-		return resp, fmt.Errorf("`blobName` cannot be an empty string")
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
 	}
 
 	if input.StartByte < 0 {
-		return resp, fmt.Errorf("`input.StartByte` must be greater than or equal to 0")
+		err = fmt.Errorf("`input.StartByte` must be greater than or equal to 0")
+		return
 	}
 
 	if input.EndByte <= 0 {
-		return resp, fmt.Errorf("`input.EndByte` must be greater than 0")
+		err = fmt.Errorf("`input.EndByte` must be greater than 0")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -61,7 +65,11 @@ func (c Client) PutPageClear(ctx context.Context, containerName, blobName string
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/blob/blobs/put_page_update.go
+++ b/storage/2023-11-03/blob/blobs/put_page_update.go
@@ -1,8 +1,10 @@
 package blobs
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -85,9 +87,9 @@ func (c Client) PutPageUpdate(ctx context.Context, containerName, blobName strin
 		return
 	}
 
-	// TODO commenting these out to see if they're really needed (net/http should do this) (@manicminer)
-	//req.Body = io.NopCloser(bytes.NewReader(input.Content))
-	//req.ContentLength = int64(len(input.Content))
+	// this is needed to avoid `Content-Length: 0` in the request
+	req.Body = io.NopCloser(bytes.NewReader(input.Content))
+	req.ContentLength = int64(len(input.Content))
 
 	var resp *client.Response
 	resp, err = req.Execute(ctx)

--- a/storage/2023-11-03/blob/blobs/set_tier.go
+++ b/storage/2023-11-03/blob/blobs/set_tier.go
@@ -15,22 +15,24 @@ type SetTierInput struct {
 }
 
 type SetTierResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // SetTier sets the tier on a blob.
-func (c Client) SetTier(ctx context.Context, containerName, blobName string, input SetTierInput) (resp SetTierResponse, err error) {
-
+func (c Client) SetTier(ctx context.Context, containerName, blobName string, input SetTierInput) (result SetTierResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(containerName) != containerName {
-		return resp, fmt.Errorf("`containerName` must be a lower-cased string")
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
 	}
 
 	if blobName == "" {
-		return resp, fmt.Errorf("`blobName` cannot be an empty string")
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -51,7 +53,11 @@ func (c Client) SetTier(ctx context.Context, containerName, blobName string, inp
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/blob/blobs/snapshot_get_properties.go
+++ b/storage/2023-11-03/blob/blobs/snapshot_get_properties.go
@@ -3,13 +3,13 @@ package blobs
 import (
 	"context"
 	"fmt"
+	"github.com/tombuildsstuff/giovanni/storage/internal/metadata"
 	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/client"
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
-	"github.com/tombuildsstuff/giovanni/storage/internal/metadata"
 )
 
 type GetSnapshotPropertiesInput struct {
@@ -23,22 +23,25 @@ type GetSnapshotPropertiesInput struct {
 
 // GetSnapshotProperties returns all user-defined metadata, standard HTTP properties, and system properties for
 // the specified snapshot of a blob
-func (c Client) GetSnapshotProperties(ctx context.Context, containerName, blobName string, input GetSnapshotPropertiesInput) (resp GetPropertiesResponse, err error) {
-
+func (c Client) GetSnapshotProperties(ctx context.Context, containerName, blobName string, input GetSnapshotPropertiesInput) (result GetPropertiesResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(containerName) != containerName {
-		return resp, fmt.Errorf("`containerName` must be a lower-cased string")
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
 	}
 
 	if blobName == "" {
-		return resp, fmt.Errorf("`blobName` cannot be an empty string")
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
 	}
 
 	if input.SnapshotID == "" {
-		return resp, fmt.Errorf("`input.SnapshotID` cannot be an empty string")
+		err = fmt.Errorf("`input.SnapshotID` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -58,80 +61,85 @@ func (c Client) GetSnapshotProperties(ctx context.Context, containerName, blobNa
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+
+		if resp.Header != nil {
+			result.AccessTier = AccessTier(resp.Header.Get("x-ms-access-tier"))
+			result.AccessTierChangeTime = resp.Header.Get("x-ms-access-tier-change-time")
+			result.ArchiveStatus = ArchiveStatus(resp.Header.Get("x-ms-archive-status"))
+			result.BlobCommittedBlockCount = resp.Header.Get("x-ms-blob-committed-block-count")
+			result.BlobSequenceNumber = resp.Header.Get("x-ms-blob-sequence-number")
+			result.BlobType = BlobType(resp.Header.Get("x-ms-blob-type"))
+			result.CacheControl = resp.Header.Get("Cache-Control")
+			result.ContentDisposition = resp.Header.Get("Content-Disposition")
+			result.ContentEncoding = resp.Header.Get("Content-Encoding")
+			result.ContentLanguage = resp.Header.Get("Content-Language")
+			result.ContentMD5 = resp.Header.Get("Content-MD5")
+			result.ContentType = resp.Header.Get("Content-Type")
+			result.CopyCompletionTime = resp.Header.Get("x-ms-copy-completion-time")
+			result.CopyDestinationSnapshot = resp.Header.Get("x-ms-copy-destination-snapshot")
+			result.CopyID = resp.Header.Get("x-ms-copy-id")
+			result.CopyProgress = resp.Header.Get("x-ms-copy-progress")
+			result.CopySource = resp.Header.Get("x-ms-copy-source")
+			result.CopyStatus = CopyStatus(resp.Header.Get("x-ms-copy-status"))
+			result.CopyStatusDescription = resp.Header.Get("x-ms-copy-status-description")
+			result.CreationTime = resp.Header.Get("x-ms-creation-time")
+			result.ETag = resp.Header.Get("Etag")
+			result.LastModified = resp.Header.Get("Last-Modified")
+			result.LeaseDuration = LeaseDuration(resp.Header.Get("x-ms-lease-duration"))
+			result.LeaseState = LeaseState(resp.Header.Get("x-ms-lease-state"))
+			result.LeaseStatus = LeaseStatus(resp.Header.Get("x-ms-lease-status"))
+			result.MetaData = metadata.ParseFromHeaders(resp.Header)
+
+			if v := resp.Header.Get("Content-Length"); v != "" {
+				i, innerErr := strconv.Atoi(v)
+				if innerErr != nil {
+					err = fmt.Errorf("parsing `Content-Length` header value %q: %+v", v, innerErr)
+				}
+
+				result.ContentLength = int64(i)
+			}
+
+			if v := resp.Header.Get("x-ms-access-tier-inferred"); v != "" {
+				b, innerErr := strconv.ParseBool(v)
+				if innerErr != nil {
+					err = fmt.Errorf("parsing `x-ms-access-tier-inferred` header value %q: %+v", v, innerErr)
+					return
+				}
+
+				result.AccessTierInferred = b
+			}
+
+			if v := resp.Header.Get("x-ms-incremental-copy"); v != "" {
+				b, innerErr := strconv.ParseBool(v)
+				if innerErr != nil {
+					err = fmt.Errorf("parsing `x-ms-incremental-copy` header value %q: %+v", v, innerErr)
+					return
+				}
+
+				result.IncrementalCopy = b
+			}
+
+			if v := resp.Header.Get("x-ms-server-encrypted"); v != "" {
+				b, innerErr := strconv.ParseBool(v)
+				if innerErr != nil {
+					err = fmt.Errorf("parsing `\"x-ms-server-encrypted` header value %q: %+v", v, innerErr)
+					return
+				}
+
+				result.ServerEncrypted = b
+			}
+		}
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return
 	}
 
-	if resp.HttpResponse != nil {
-		if resp.HttpResponse.Header != nil {
-			resp.AccessTier = AccessTier(resp.HttpResponse.Header.Get("x-ms-access-tier"))
-			resp.AccessTierChangeTime = resp.HttpResponse.Header.Get("x-ms-access-tier-change-time")
-			resp.ArchiveStatus = ArchiveStatus(resp.HttpResponse.Header.Get("x-ms-archive-status"))
-			resp.BlobCommittedBlockCount = resp.HttpResponse.Header.Get("x-ms-blob-committed-block-count")
-			resp.BlobSequenceNumber = resp.HttpResponse.Header.Get("x-ms-blob-sequence-number")
-			resp.BlobType = BlobType(resp.HttpResponse.Header.Get("x-ms-blob-type"))
-			resp.CacheControl = resp.HttpResponse.Header.Get("Cache-Control")
-			resp.ContentDisposition = resp.HttpResponse.Header.Get("Content-Disposition")
-			resp.ContentEncoding = resp.HttpResponse.Header.Get("Content-Encoding")
-			resp.ContentLanguage = resp.HttpResponse.Header.Get("Content-Language")
-			resp.ContentMD5 = resp.HttpResponse.Header.Get("Content-MD5")
-			resp.ContentType = resp.HttpResponse.Header.Get("Content-Type")
-			resp.CopyCompletionTime = resp.HttpResponse.Header.Get("x-ms-copy-completion-time")
-			resp.CopyDestinationSnapshot = resp.HttpResponse.Header.Get("x-ms-copy-destination-snapshot")
-			resp.CopyID = resp.HttpResponse.Header.Get("x-ms-copy-id")
-			resp.CopyProgress = resp.HttpResponse.Header.Get("x-ms-copy-progress")
-			resp.CopySource = resp.HttpResponse.Header.Get("x-ms-copy-source")
-			resp.CopyStatus = CopyStatus(resp.HttpResponse.Header.Get("x-ms-copy-status"))
-			resp.CopyStatusDescription = resp.HttpResponse.Header.Get("x-ms-copy-status-description")
-			resp.CreationTime = resp.HttpResponse.Header.Get("x-ms-creation-time")
-			resp.ETag = resp.HttpResponse.Header.Get("Etag")
-			resp.LastModified = resp.HttpResponse.Header.Get("Last-Modified")
-			resp.LeaseDuration = LeaseDuration(resp.HttpResponse.Header.Get("x-ms-lease-duration"))
-			resp.LeaseState = LeaseState(resp.HttpResponse.Header.Get("x-ms-lease-state"))
-			resp.LeaseStatus = LeaseStatus(resp.HttpResponse.Header.Get("x-ms-lease-status"))
-			resp.MetaData = metadata.ParseFromHeaders(resp.HttpResponse.Header)
-
-			if v := resp.HttpResponse.Header.Get("x-ms-access-tier-inferred"); v != "" {
-				b, innerErr := strconv.ParseBool(v)
-				if innerErr != nil {
-					err = fmt.Errorf("error parsing %q as a bool: %s", v, innerErr)
-					return
-				}
-
-				resp.AccessTierInferred = b
-			}
-
-			if v := resp.HttpResponse.Header.Get("Content-Length"); v != "" {
-				i, innerErr := strconv.Atoi(v)
-				if innerErr != nil {
-					err = fmt.Errorf("error parsing %q as an integer: %s", v, innerErr)
-				}
-
-				resp.ContentLength = int64(i)
-			}
-
-			if v := resp.HttpResponse.Header.Get("x-ms-incremental-copy"); v != "" {
-				b, innerErr := strconv.ParseBool(v)
-				if innerErr != nil {
-					err = fmt.Errorf("error parsing %q as a bool: %s", v, innerErr)
-					return
-				}
-
-				resp.IncrementalCopy = b
-			}
-
-			if v := resp.HttpResponse.Header.Get("x-ms-server-encrypted"); v != "" {
-				b, innerErr := strconv.ParseBool(v)
-				if innerErr != nil {
-					err = fmt.Errorf("error parsing %q as a bool: %s", v, innerErr)
-					return
-				}
-
-				resp.ServerEncrypted = b
-			}
-		}
+	if result.HttpResponse != nil {
 	}
 
 	return

--- a/storage/2023-11-03/blob/blobs/snapshot_get_properties.go
+++ b/storage/2023-11-03/blob/blobs/snapshot_get_properties.go
@@ -3,13 +3,13 @@ package blobs
 import (
 	"context"
 	"fmt"
-	"github.com/tombuildsstuff/giovanni/storage/internal/metadata"
 	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/client"
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/tombuildsstuff/giovanni/storage/internal/metadata"
 )
 
 type GetSnapshotPropertiesInput struct {

--- a/storage/2023-11-03/blob/blobs/undelete.go
+++ b/storage/2023-11-03/blob/blobs/undelete.go
@@ -11,22 +11,24 @@ import (
 )
 
 type UndeleteResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Undelete restores the contents and metadata of soft deleted blob and any associated soft deleted snapshots.
-func (c Client) Undelete(ctx context.Context, containerName, blobName string) (resp UndeleteResponse, err error) {
-
+func (c Client) Undelete(ctx context.Context, containerName, blobName string) (result UndeleteResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(containerName) != containerName {
-		return resp, fmt.Errorf("`containerName` must be a lower-cased string")
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
 	}
 
 	if blobName == "" {
-		return resp, fmt.Errorf("`blobName` cannot be an empty string")
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -44,7 +46,11 @@ func (c Client) Undelete(ctx context.Context, containerName, blobName string) (r
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/blob/containers/delete.go
+++ b/storage/2023-11-03/blob/containers/delete.go
@@ -9,14 +9,15 @@ import (
 )
 
 type DeleteResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Delete marks the specified container for deletion.
 // The container and any blobs contained within it are later deleted during garbage collection.
-func (c Client) Delete(ctx context.Context, containerName string) (resp DeleteResponse, err error) {
+func (c Client) Delete(ctx context.Context, containerName string) (result DeleteResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -28,12 +29,18 @@ func (c Client) Delete(ctx context.Context, containerName string) (resp DeleteRe
 		OptionsObject: containerOptions{},
 		Path:          fmt.Sprintf("/%s", containerName),
 	}
+
 	req, err := c.Client.NewRequest(ctx, opts)
 	if err != nil {
 		err = fmt.Errorf("building request: %+v", err)
 		return
 	}
-	resp.HttpResponse, err = req.Execute(ctx)
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/blob/containers/lease_release.go
+++ b/storage/2023-11-03/blob/containers/lease_release.go
@@ -14,16 +14,18 @@ type ReleaseLeaseInput struct {
 }
 
 type ReleaseLeaseResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // ReleaseLease releases the lock based on the Lease ID
-func (c Client) ReleaseLease(ctx context.Context, containerName string, input ReleaseLeaseInput) (resp ReleaseLeaseResponse, err error) {
+func (c Client) ReleaseLease(ctx context.Context, containerName string, input ReleaseLeaseInput) (result ReleaseLeaseResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
 	}
 	if input.LeaseId == "" {
-		return resp, fmt.Errorf("`input.LeaseId` cannot be an empty string")
+		err = fmt.Errorf("`input.LeaseId` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -37,12 +39,18 @@ func (c Client) ReleaseLease(ctx context.Context, containerName string, input Re
 		},
 		Path: fmt.Sprintf("/%s", containerName),
 	}
+
 	req, err := c.Client.NewRequest(ctx, opts)
 	if err != nil {
 		err = fmt.Errorf("building request: %+v", err)
 		return
 	}
-	resp.HttpResponse, err = req.Execute(ctx)
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/blob/containers/lease_renew.go
+++ b/storage/2023-11-03/blob/containers/lease_renew.go
@@ -14,16 +14,18 @@ type RenewLeaseInput struct {
 }
 
 type RenewLeaseResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // RenewLease renews the lock based on the Lease ID
-func (c Client) RenewLease(ctx context.Context, containerName string, input RenewLeaseInput) (resp RenewLeaseResponse, err error) {
+func (c Client) RenewLease(ctx context.Context, containerName string, input RenewLeaseInput) (result RenewLeaseResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
 	}
 	if input.LeaseId == "" {
-		return resp, fmt.Errorf("`input.LeaseId` cannot be an empty string")
+		err = fmt.Errorf("`input.LeaseId` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -37,12 +39,18 @@ func (c Client) RenewLease(ctx context.Context, containerName string, input Rene
 		},
 		Path: fmt.Sprintf("/%s", containerName),
 	}
+
 	req, err := c.Client.NewRequest(ctx, opts)
 	if err != nil {
 		err = fmt.Errorf("building request: %+v", err)
 		return
 	}
-	resp.HttpResponse, err = req.Execute(ctx)
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/blob/containers/set_acl.go
+++ b/storage/2023-11-03/blob/containers/set_acl.go
@@ -15,14 +15,15 @@ type SetAccessControlInput struct {
 }
 
 type SetAccessControlResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // SetAccessControl sets the Access Control for a Container without a Lease ID
 // NOTE: The SetAccessControl operation only supports Shared Key authorization.
-func (c Client) SetAccessControl(ctx context.Context, containerName string, input SetAccessControlInput) (resp SetAccessControlResponse, err error) {
+func (c Client) SetAccessControl(ctx context.Context, containerName string, input SetAccessControlInput) (result SetAccessControlResponse, err error) {
 	if containerName == "" {
-		return resp, fmt.Errorf("`containerName` cannot be an empty string")
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -37,12 +38,18 @@ func (c Client) SetAccessControl(ctx context.Context, containerName string, inpu
 		},
 		Path: fmt.Sprintf("/%s", containerName),
 	}
+
 	req, err := c.Client.NewRequest(ctx, opts)
 	if err != nil {
 		err = fmt.Errorf("building request: %+v", err)
 		return
 	}
-	resp.HttpResponse, err = req.Execute(ctx)
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/datalakestore/filesystems/create.go
+++ b/storage/2023-11-03/datalakestore/filesystems/create.go
@@ -18,14 +18,14 @@ type CreateInput struct {
 }
 
 type CreateResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Create creates a Data Lake Store Gen2 FileSystem within a Storage Account
-func (c Client) Create(ctx context.Context, fileSystemName string, input CreateInput) (resp CreateResponse, err error) {
-
+func (c Client) Create(ctx context.Context, fileSystemName string, input CreateInput) (result CreateResponse, err error) {
 	if fileSystemName == "" {
-		return resp, fmt.Errorf("`fileSystemName` cannot be an empty string")
+		err = fmt.Errorf("`fileSystemName` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -42,12 +42,16 @@ func (c Client) Create(ctx context.Context, fileSystemName string, input CreateI
 	}
 
 	req, err := c.Client.NewRequest(ctx, opts)
-
 	if err != nil {
 		err = fmt.Errorf("building request: %+v", err)
 		return
 	}
-	resp.HttpResponse, err = req.Execute(ctx)
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/datalakestore/filesystems/delete.go
+++ b/storage/2023-11-03/datalakestore/filesystems/delete.go
@@ -9,14 +9,14 @@ import (
 )
 
 type DeleteResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Delete deletes a Data Lake Store Gen2 FileSystem within a Storage Account
-func (c Client) Delete(ctx context.Context, fileSystemName string) (resp DeleteResponse, err error) {
-
+func (c Client) Delete(ctx context.Context, fileSystemName string) (result DeleteResponse, err error) {
 	if fileSystemName == "" {
-		return resp, fmt.Errorf("`fileSystemName` cannot be an empty string")
+		err = fmt.Errorf("`fileSystemName` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -28,12 +28,18 @@ func (c Client) Delete(ctx context.Context, fileSystemName string) (resp DeleteR
 		OptionsObject: fileSystemOptions{},
 		Path:          fmt.Sprintf("/%s", fileSystemName),
 	}
+
 	req, err := c.Client.NewRequest(ctx, opts)
 	if err != nil {
 		err = fmt.Errorf("building request: %+v", err)
 		return
 	}
-	resp.HttpResponse, err = req.Execute(ctx)
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/datalakestore/filesystems/helpers.go
+++ b/storage/2023-11-03/datalakestore/filesystems/helpers.go
@@ -29,7 +29,7 @@ func parseProperties(input string) (*map[string]string, error) {
 		// as such we can't string split on that -_-
 		position := strings.Index(propertyRaw, "=")
 		if position < 0 {
-			return nil, fmt.Errorf("Expected there to be an equals in the key value pair: %q", propertyRaw)
+			return nil, fmt.Errorf("expected an equal sign in the key value pair: %q", propertyRaw)
 		}
 
 		key := propertyRaw[0:position]

--- a/storage/2023-11-03/datalakestore/filesystems/properties_get.go
+++ b/storage/2023-11-03/datalakestore/filesystems/properties_get.go
@@ -3,9 +3,10 @@ package filesystems
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-azure-sdk/sdk/client"
 	"net/http"
 	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
 )
 
 type GetPropertiesResponse struct {

--- a/storage/2023-11-03/datalakestore/filesystems/properties_set.go
+++ b/storage/2023-11-03/datalakestore/filesystems/properties_set.go
@@ -26,14 +26,14 @@ type SetPropertiesInput struct {
 }
 
 type SetPropertiesResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // SetProperties sets the Properties for a Data Lake Store Gen2 FileSystem within a Storage Account
-func (c Client) SetProperties(ctx context.Context, fileSystemName string, input SetPropertiesInput) (resp SetPropertiesResponse, err error) {
-
+func (c Client) SetProperties(ctx context.Context, fileSystemName string, input SetPropertiesInput) (result SetPropertiesResponse, err error) {
 	if fileSystemName == "" {
-		return resp, fmt.Errorf("`fileSystemName` cannot be an empty string")
+		err = fmt.Errorf("`fileSystemName` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -52,12 +52,16 @@ func (c Client) SetProperties(ctx context.Context, fileSystemName string, input 
 	}
 
 	req, err := c.Client.NewRequest(ctx, opts)
-
 	if err != nil {
 		err = fmt.Errorf("building request: %+v", err)
 		return
 	}
-	resp.HttpResponse, err = req.Execute(ctx)
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/datalakestore/paths/create.go
+++ b/storage/2023-11-03/datalakestore/paths/create.go
@@ -19,14 +19,14 @@ type CreateInput struct {
 }
 
 type CreateResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Create creates a Data Lake Store Gen2 Path within a Storage Account
-func (c Client) Create(ctx context.Context, fileSystemName string, path string, input CreateInput) (resp CreateResponse, err error) {
+func (c Client) Create(ctx context.Context, fileSystemName string, path string, input CreateInput) (result CreateResponse, err error) {
 
 	if fileSystemName == "" {
-		return resp, fmt.Errorf("`fileSystemName` cannot be an empty string")
+		return result, fmt.Errorf("`fileSystemName` cannot be an empty string")
 	}
 
 	opts := client.RequestOptions{
@@ -46,12 +46,17 @@ func (c Client) Create(ctx context.Context, fileSystemName string, path string, 
 
 	if err != nil {
 		err = fmt.Errorf("building request: %+v", err)
-		return resp, err
+		return result, err
 	}
-	resp.HttpResponse, err = req.Execute(ctx)
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
-		return resp, err
+		return result, err
 	}
 
 	return

--- a/storage/2023-11-03/datalakestore/paths/delete.go
+++ b/storage/2023-11-03/datalakestore/paths/delete.go
@@ -9,14 +9,14 @@ import (
 )
 
 type DeleteResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Delete deletes a Data Lake Store Gen2 FileSystem within a Storage Account
-func (c Client) Delete(ctx context.Context, fileSystemName string, path string) (resp DeleteResponse, err error) {
+func (c Client) Delete(ctx context.Context, fileSystemName string, path string) (result DeleteResponse, err error) {
 
 	if fileSystemName == "" {
-		return resp, fmt.Errorf("`fileSystemName` cannot be an empty string")
+		return result, fmt.Errorf("`fileSystemName` cannot be an empty string")
 	}
 
 	opts := client.RequestOptions{
@@ -33,7 +33,12 @@ func (c Client) Delete(ctx context.Context, fileSystemName string, path string) 
 		err = fmt.Errorf("building request: %+v", err)
 		return
 	}
-	resp.HttpResponse, err = req.Execute(ctx)
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/datalakestore/paths/helpers.go
+++ b/storage/2023-11-03/datalakestore/paths/helpers.go
@@ -11,5 +11,5 @@ func parsePathResource(input string) (PathResource, error) {
 	case "directory":
 		return PathResourceDirectory, nil
 	}
-	return "", fmt.Errorf("Unhandled path resource type %q", input)
+	return "", fmt.Errorf("unhandled path resource type %q", input)
 }

--- a/storage/2023-11-03/datalakestore/paths/lifecycle_test.go
+++ b/storage/2023-11-03/datalakestore/paths/lifecycle_test.go
@@ -71,7 +71,7 @@ func TestLifecycle(t *testing.T) {
 	}
 
 	t.Logf("[DEBUG] Getting properties for folder 'test' ..")
-	props, err := pathsClient.GetProperties(ctx, fileSystemName, path, GetPropertiesInput{action: GetPropertiesActionGetAccessControl})
+	props, err := pathsClient.GetProperties(ctx, fileSystemName, path, GetPropertiesInput{Action: GetPropertiesActionGetAccessControl})
 	if err != nil {
 		t.Fatal(fmt.Errorf("error getting properties: %s", err))
 	}
@@ -94,7 +94,7 @@ func TestLifecycle(t *testing.T) {
 	}
 
 	t.Logf("[DEBUG] Getting properties for folder 'test' (2) ..")
-	props, err = pathsClient.GetProperties(ctx, fileSystemName, path, GetPropertiesInput{action: GetPropertiesActionGetAccessControl})
+	props, err = pathsClient.GetProperties(ctx, fileSystemName, path, GetPropertiesInput{Action: GetPropertiesActionGetAccessControl})
 	if err != nil {
 		t.Fatal(fmt.Errorf("error getting properties (2): %s", err))
 	}
@@ -108,7 +108,7 @@ func TestLifecycle(t *testing.T) {
 	}
 
 	t.Logf("[DEBUG] Getting properties for folder 'test' (3) ..")
-	props, err = pathsClient.GetProperties(ctx, fileSystemName, path, GetPropertiesInput{action: GetPropertiesActionGetAccessControl})
+	props, err = pathsClient.GetProperties(ctx, fileSystemName, path, GetPropertiesInput{Action: GetPropertiesActionGetAccessControl})
 	if err == nil {
 		t.Fatal(fmt.Errorf("didn't get error getting properties after deleting path (3)"))
 	}

--- a/storage/2023-11-03/datalakestore/paths/properties_set.go
+++ b/storage/2023-11-03/datalakestore/paths/properties_set.go
@@ -24,14 +24,14 @@ type SetAccessControlInput struct {
 }
 
 type SetPropertiesResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // SetProperties sets the access control properties for a Data Lake Store Gen2 Path within a Storage Account File System
-func (c Client) SetAccessControl(ctx context.Context, fileSystemName string, path string, input SetAccessControlInput) (resp SetPropertiesResponse, err error) {
-
+func (c Client) SetAccessControl(ctx context.Context, fileSystemName string, path string, input SetAccessControlInput) (result SetPropertiesResponse, err error) {
 	if fileSystemName == "" {
-		return resp, fmt.Errorf("`fileSystemName` cannot be an empty string")
+		err = fmt.Errorf("`fileSystemName` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -50,13 +50,17 @@ func (c Client) SetAccessControl(ctx context.Context, fileSystemName string, pat
 
 	if err != nil {
 		err = fmt.Errorf("building request: %+v", err)
-		return resp, err
+		return result, err
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
-		return resp, err
+		return result, err
 	}
 
 	return

--- a/storage/2023-11-03/file/directories/create.go
+++ b/storage/2023-11-03/file/directories/create.go
@@ -28,26 +28,30 @@ type CreateDirectoryInput struct {
 }
 
 type CreateDirectoryResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Create creates a new directory under the specified share or parent directory.
-func (c Client) Create(ctx context.Context, shareName, path string, input CreateDirectoryInput) (resp CreateDirectoryResponse, err error) {
+func (c Client) Create(ctx context.Context, shareName, path string, input CreateDirectoryInput) (result CreateDirectoryResponse, err error) {
 
 	if shareName == "" {
-		return resp, fmt.Errorf("`shareName` cannot be an empty string")
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(shareName) != shareName {
-		return resp, fmt.Errorf("`shareName` must be a lower-cased string")
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
 	}
 
 	if err = metadata.Validate(input.MetaData); err != nil {
-		return resp, fmt.Errorf("`input.MetaData` is not valid: %s", err)
+		err = fmt.Errorf("`input.MetaData` is not valid: %s", err)
+		return
 	}
 
 	if path == "" {
-		return resp, fmt.Errorf("`path` cannot be an empty string")
+		err = fmt.Errorf("`path` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -68,7 +72,11 @@ func (c Client) Create(ctx context.Context, shareName, path string, input Create
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/file/directories/delete.go
+++ b/storage/2023-11-03/file/directories/delete.go
@@ -10,23 +10,26 @@ import (
 )
 
 type DeleteResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Delete removes the specified empty directory
 // Note that the directory must be empty before it can be deleted.
-func (c Client) Delete(ctx context.Context, shareName, path string) (resp DeleteResponse, err error) {
+func (c Client) Delete(ctx context.Context, shareName, path string) (result DeleteResponse, err error) {
 
 	if shareName == "" {
-		return resp, fmt.Errorf("`shareName` cannot be an empty string")
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(shareName) != shareName {
-		return resp, fmt.Errorf("`shareName` must be a lower-cased string")
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
 	}
 
 	if path == "" {
-		return resp, fmt.Errorf("`path` cannot be an empty string")
+		err = fmt.Errorf("`path` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -45,7 +48,11 @@ func (c Client) Delete(ctx context.Context, shareName, path string) (resp Delete
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/file/directories/metadata_set.go
+++ b/storage/2023-11-03/file/directories/metadata_set.go
@@ -12,7 +12,7 @@ import (
 )
 
 type SetMetaDataResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 type SetMetaDataInput struct {
@@ -20,22 +20,26 @@ type SetMetaDataInput struct {
 }
 
 // SetMetaData updates user defined metadata for the specified directory
-func (c Client) SetMetaData(ctx context.Context, shareName, path string, input SetMetaDataInput) (resp SetMetaDataResponse, err error) {
+func (c Client) SetMetaData(ctx context.Context, shareName, path string, input SetMetaDataInput) (result SetMetaDataResponse, err error) {
 
 	if shareName == "" {
-		return resp, fmt.Errorf("`shareName` cannot be an empty string")
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(shareName) != shareName {
-		return resp, fmt.Errorf("`shareName` must be a lower-cased string")
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
 	}
 
-	if err := metadata.Validate(input.MetaData); err != nil {
-		return resp, fmt.Errorf("`metadata` is not valid: %s", err)
+	if err = metadata.Validate(input.MetaData); err != nil {
+		err = fmt.Errorf("`metadata` is not valid: %s", err)
+		return
 	}
 
 	if path == "" {
-		return resp, fmt.Errorf("`path` cannot be an empty string")
+		err = fmt.Errorf("`path` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -56,7 +60,11 @@ func (c Client) SetMetaData(ctx context.Context, shareName, path string, input S
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/file/files/copy_abort.go
+++ b/storage/2023-11-03/file/files/copy_abort.go
@@ -15,26 +15,30 @@ type CopyAbortInput struct {
 }
 
 type CopyAbortResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // AbortCopy aborts a pending Copy File operation, and leaves a destination file with zero length and full metadata
-func (c Client) AbortCopy(ctx context.Context, shareName, path, fileName string, input CopyAbortInput) (resp CopyAbortResponse, err error) {
+func (c Client) AbortCopy(ctx context.Context, shareName, path, fileName string, input CopyAbortInput) (result CopyAbortResponse, err error) {
 
 	if shareName == "" {
-		return resp, fmt.Errorf("`shareName` cannot be an empty string")
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(shareName) != shareName {
-		return resp, fmt.Errorf("`shareName` must be a lower-cased string")
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
 	}
 
 	if fileName == "" {
-		return resp, fmt.Errorf("`fileName` cannot be an empty string")
+		err = fmt.Errorf("`fileName` cannot be an empty string")
+		return
 	}
 
 	if input.copyID == "" {
-		return resp, fmt.Errorf("`copyID` cannot be an empty string")
+		err = fmt.Errorf("`copyID` cannot be an empty string")
+		return
 	}
 
 	if path != "" {
@@ -59,7 +63,11 @@ func (c Client) AbortCopy(ctx context.Context, shareName, path, fileName string,
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/file/files/copy_wait.go
+++ b/storage/2023-11-03/file/files/copy_wait.go
@@ -9,20 +9,20 @@ import (
 )
 
 // CopyAndWait is a convenience method which doesn't exist in the API, which copies the file and then waits for the copy to complete
-func (c Client) CopyAndWait(ctx context.Context, shareName, path, fileName string, input CopyInput) (resp CopyResponse, err error) {
-	copy, e := c.Copy(ctx, shareName, path, fileName, input)
+func (c Client) CopyAndWait(ctx context.Context, shareName, path, fileName string, input CopyInput) (result CopyResponse, err error) {
+	fileCopy, e := c.Copy(ctx, shareName, path, fileName, input)
 	if err != nil {
-		resp.HttpResponse = copy.HttpResponse
-		err = fmt.Errorf("error copying: %s", e)
+		result.HttpResponse = fileCopy.HttpResponse
+		err = fmt.Errorf("copying: %s", e)
 		return
 	}
 
-	resp.CopyID = copy.CopyID
+	result.CopyID = fileCopy.CopyID
 
 	pollerType := NewCopyAndWaitPoller(&c, shareName, path, fileName)
 	poller := pollers.NewPoller(pollerType, 10*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
-	if err := poller.PollUntilDone(ctx); err != nil {
-		return resp, fmt.Errorf("waiting for file to copy: %+v", err)
+	if err = poller.PollUntilDone(ctx); err != nil {
+		return result, fmt.Errorf("waiting for file to copy: %+v", err)
 	}
 
 	return

--- a/storage/2023-11-03/file/files/create.go
+++ b/storage/2023-11-03/file/files/create.go
@@ -51,25 +51,29 @@ type CreateInput struct {
 }
 
 type CreateResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Create creates a new file or replaces a file.
-func (c Client) Create(ctx context.Context, shareName, path, fileName string, input CreateInput) (resp CreateResponse, err error) {
+func (c Client) Create(ctx context.Context, shareName, path, fileName string, input CreateInput) (result CreateResponse, err error) {
 	if shareName == "" {
-		return resp, fmt.Errorf("`shareName` cannot be an empty string")
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(shareName) != shareName {
-		return resp, fmt.Errorf("`shareName` must be a lower-cased string")
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
 	}
 
 	if fileName == "" {
-		return resp, fmt.Errorf("`fileName` cannot be an empty string")
+		err = fmt.Errorf("`fileName` cannot be an empty string")
+		return
 	}
 
 	if err = metadata.Validate(input.MetaData); err != nil {
-		return resp, fmt.Errorf("`input.MetaData` is not valid: %s", err)
+		err = fmt.Errorf("`input.MetaData` is not valid: %s", err)
+		return
 	}
 
 	if path != "" {
@@ -94,7 +98,11 @@ func (c Client) Create(ctx context.Context, shareName, path, fileName string, in
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/file/files/delete.go
+++ b/storage/2023-11-03/file/files/delete.go
@@ -10,22 +10,25 @@ import (
 )
 
 type DeleteResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Delete immediately deletes the file from the File Share.
-func (c Client) Delete(ctx context.Context, shareName, path, fileName string) (resp DeleteResponse, err error) {
+func (c Client) Delete(ctx context.Context, shareName, path, fileName string) (result DeleteResponse, err error) {
 
 	if shareName == "" {
-		return resp, fmt.Errorf("`shareName` cannot be an empty string")
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(shareName) != shareName {
-		return resp, fmt.Errorf("`shareName` must be a lower-cased string")
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
 	}
 
 	if fileName == "" {
-		return resp, fmt.Errorf("`fileName` cannot be an empty string")
+		err = fmt.Errorf("`fileName` cannot be an empty string")
+		return
 	}
 
 	if path != "" {
@@ -48,7 +51,11 @@ func (c Client) Delete(ctx context.Context, shareName, path, fileName string) (r
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/file/files/metadata_get.go
+++ b/storage/2023-11-03/file/files/metadata_get.go
@@ -3,12 +3,12 @@ package files
 import (
 	"context"
 	"fmt"
-	"github.com/tombuildsstuff/giovanni/storage/internal/metadata"
 	"net/http"
 	"strings"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/client"
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/tombuildsstuff/giovanni/storage/internal/metadata"
 )
 
 type GetMetaDataResponse struct {

--- a/storage/2023-11-03/file/files/metadata_set.go
+++ b/storage/2023-11-03/file/files/metadata_set.go
@@ -12,7 +12,7 @@ import (
 )
 
 type SetMetaDataResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 type SetMetaDataInput struct {
@@ -20,21 +20,25 @@ type SetMetaDataInput struct {
 }
 
 // SetMetaData updates the specified File to have the specified MetaData.
-func (c Client) SetMetaData(ctx context.Context, shareName, path, fileName string, input SetMetaDataInput) (resp SetMetaDataResponse, err error) {
+func (c Client) SetMetaData(ctx context.Context, shareName, path, fileName string, input SetMetaDataInput) (result SetMetaDataResponse, err error) {
 	if shareName == "" {
-		return resp, fmt.Errorf("`shareName` cannot be an empty string")
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(shareName) != shareName {
-		return resp, fmt.Errorf("`shareName` must be a lower-cased string")
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
 	}
 
 	if fileName == "" {
-		return resp, fmt.Errorf("`fileName` cannot be an empty string")
+		err = fmt.Errorf("`fileName` cannot be an empty string")
+		return
 	}
 
 	if err = metadata.Validate(input.MetaData); err != nil {
-		return resp, fmt.Errorf("`input.MetaData` is not valid: %s", err)
+		err = fmt.Errorf("`input.MetaData` is not valid: %s", err)
+		return
 	}
 
 	if path != "" {
@@ -59,7 +63,11 @@ func (c Client) SetMetaData(ctx context.Context, shareName, path, fileName strin
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/file/files/properties_get.go
+++ b/storage/2023-11-03/file/files/properties_get.go
@@ -3,12 +3,12 @@ package files
 import (
 	"context"
 	"fmt"
-	"github.com/tombuildsstuff/giovanni/storage/internal/metadata"
 	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/tombuildsstuff/giovanni/storage/internal/metadata"
 )
 
 type GetResponse struct {
@@ -95,7 +95,7 @@ func (c Client) GetProperties(ctx context.Context, shareName, path, fileName str
 				var contentLength int
 				contentLength, err = strconv.Atoi(contentLengthRaw)
 				if err != nil {
-					err = fmt.Errorf("parsing %q for Content-Length as an integer: %s", contentLengthRaw, err)
+					err = fmt.Errorf("parsing `Content-Length` header value %q: %s", contentLengthRaw, err)
 					return
 				}
 				contentLengthI64 := int64(contentLength)

--- a/storage/2023-11-03/file/files/properties_set.go
+++ b/storage/2023-11-03/file/files/properties_set.go
@@ -68,21 +68,24 @@ type SetPropertiesInput struct {
 }
 
 type SetPropertiesResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // SetProperties sets the specified properties on the specified File
-func (c Client) SetProperties(ctx context.Context, shareName, path, fileName string, input SetPropertiesInput) (resp SetPropertiesResponse, err error) {
+func (c Client) SetProperties(ctx context.Context, shareName, path, fileName string, input SetPropertiesInput) (result SetPropertiesResponse, err error) {
 	if shareName == "" {
-		return resp, fmt.Errorf("`shareName` cannot be an empty string")
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(shareName) != shareName {
-		return resp, fmt.Errorf("`shareName` must be a lower-cased string")
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
 	}
 
 	if fileName == "" {
-		return resp, fmt.Errorf("`fileName` cannot be an empty string")
+		err = fmt.Errorf("`fileName` cannot be an empty string")
+		return
 	}
 
 	if path != "" {
@@ -107,7 +110,11 @@ func (c Client) SetProperties(ctx context.Context, shareName, path, fileName str
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/file/files/range_clear.go
+++ b/storage/2023-11-03/file/files/range_clear.go
@@ -16,30 +16,35 @@ type ClearByteRangeInput struct {
 }
 
 type ClearByteRangeResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // ClearByteRange clears the specified Byte Range from within the specified File
-func (c Client) ClearByteRange(ctx context.Context, shareName, path, fileName string, input ClearByteRangeInput) (resp ClearByteRangeResponse, err error) {
+func (c Client) ClearByteRange(ctx context.Context, shareName, path, fileName string, input ClearByteRangeInput) (result ClearByteRangeResponse, err error) {
 
 	if shareName == "" {
-		return resp, fmt.Errorf("`shareName` cannot be an empty string")
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(shareName) != shareName {
-		return resp, fmt.Errorf("`shareName` must be a lower-cased string")
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
 	}
 
 	if fileName == "" {
-		return resp, fmt.Errorf("`fileName` cannot be an empty string")
+		err = fmt.Errorf("`fileName` cannot be an empty string")
+		return
 	}
 
 	if input.StartBytes < 0 {
-		return resp, fmt.Errorf("`input.StartBytes` must be greater or equal to 0")
+		err = fmt.Errorf("`input.StartBytes` must be greater or equal to 0")
+		return
 	}
 
 	if input.EndBytes <= 0 {
-		return resp, fmt.Errorf("`input.EndBytes` must be greater than 0")
+		err = fmt.Errorf("`input.EndBytes` must be greater than 0")
+		return
 	}
 
 	if path != "" {
@@ -64,7 +69,11 @@ func (c Client) ClearByteRange(ctx context.Context, shareName, path, fileName st
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/file/files/range_get_file.go
+++ b/storage/2023-11-03/file/files/range_get_file.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"net/http"
 	"runtime"
 	"sync"
-
-	"github.com/hashicorp/go-azure-sdk/sdk/client"
 )
 
 type GetFileInput struct {
@@ -16,18 +15,18 @@ type GetFileInput struct {
 }
 
 type GetFileResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 
 	OutputBytes []byte
 }
 
 // GetFile is a helper method to download a file by chunking it automatically
-func (c Client) GetFile(ctx context.Context, shareName, path, fileName string, input GetFileInput) (resp GetFileResponse, err error) {
+func (c Client) GetFile(ctx context.Context, shareName, path, fileName string, input GetFileInput) (result GetFileResponse, err error) {
 
 	// first look up the file and check out how many bytes it is
 	file, e := c.GetProperties(ctx, shareName, path, fileName)
 	if err != nil {
-		resp.HttpResponse = file.HttpResponse
+		result.HttpResponse = file.HttpResponse
 		err = e
 		return
 	}
@@ -37,7 +36,7 @@ func (c Client) GetFile(ctx context.Context, shareName, path, fileName string, i
 		return
 	}
 
-	resp.HttpResponse = file.HttpResponse
+	result.HttpResponse = file.HttpResponse
 	length := *file.ContentLength
 	chunkSize := int64(4 * 1024 * 1024) // 4MB
 
@@ -95,7 +94,7 @@ func (c Client) GetFile(ctx context.Context, shareName, path, fileName string, i
 		copy(output[v.startBytes:v.endBytes], v.bytes)
 	}
 
-	resp.OutputBytes = output
+	result.OutputBytes = output
 	return
 }
 

--- a/storage/2023-11-03/file/files/range_put_file.go
+++ b/storage/2023-11-03/file/files/range_put_file.go
@@ -66,7 +66,7 @@ func (c Client) PutFile(ctx context.Context, shareName, path, fileName string, f
 
 	// TODO: we should switch to hashicorp/multi-error here
 	if len(errors) > 0 {
-		return fmt.Errorf("Error uploading file: %s", <-errors)
+		return fmt.Errorf("uploading file: %s", <-errors)
 	}
 
 	return nil
@@ -94,7 +94,7 @@ func (c Client) uploadChunk(ctx context.Context, shareName, path, fileName strin
 	_, err = file.ReadAt(bytes, startBytes)
 	if err != nil {
 		if err != io.EOF {
-			return result, fmt.Errorf("Error reading bytes: %s", err)
+			return result, fmt.Errorf("reading bytes: %s", err)
 		}
 	}
 
@@ -105,7 +105,7 @@ func (c Client) uploadChunk(ctx context.Context, shareName, path, fileName strin
 	}
 	result, err = c.PutByteRange(ctx, shareName, path, fileName, putBytesInput)
 	if err != nil {
-		return result, fmt.Errorf("error putting bytes: %s", err)
+		return result, fmt.Errorf("putting bytes: %s", err)
 	}
 
 	return

--- a/storage/2023-11-03/file/shares/delete.go
+++ b/storage/2023-11-03/file/shares/delete.go
@@ -11,7 +11,7 @@ import (
 )
 
 type DeleteResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 type DeleteInput struct {
@@ -19,13 +19,15 @@ type DeleteInput struct {
 }
 
 // Delete deletes the specified Storage Share from within a Storage Account
-func (c Client) Delete(ctx context.Context, shareName string, input DeleteInput) (resp DeleteResponse, err error) {
+func (c Client) Delete(ctx context.Context, shareName string, input DeleteInput) (result DeleteResponse, err error) {
 	if shareName == "" {
-		return resp, fmt.Errorf("`shareName` cannot be an empty string")
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(shareName) != shareName {
-		return resp, fmt.Errorf("`shareName` must be a lower-cased string")
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -45,7 +47,11 @@ func (c Client) Delete(ctx context.Context, shareName string, input DeleteInput)
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/file/shares/lifecycle_test.go
+++ b/storage/2023-11-03/file/shares/lifecycle_test.go
@@ -89,7 +89,7 @@ func TestSharesLifecycle(t *testing.T) {
 		t.Fatalf("Expected EnabledProtocol to SMB but got: %s", share.EnabledProtocol)
 	}
 	if share.AccessTier == nil || *share.AccessTier != CoolAccessTier {
-		t.Fatalf("Expected AccessTier to be Cool but got: %v", share.AccessTier)
+		t.Fatalf("Expected AccessTier to be Cool but got: %+v", share.AccessTier)
 	}
 
 	newTier := HotAccessTier
@@ -112,7 +112,7 @@ func TestSharesLifecycle(t *testing.T) {
 	}
 
 	if share.AccessTier == nil || *share.AccessTier != HotAccessTier {
-		t.Fatalf("Expected AccessTier to be Hot but got: %v", share.AccessTier)
+		t.Fatalf("Expected AccessTier to be Hot but got: %+v", share.AccessTier)
 	}
 
 	updatedMetaData := map[string]string{

--- a/storage/2023-11-03/file/shares/metadata_set.go
+++ b/storage/2023-11-03/file/shares/metadata_set.go
@@ -12,7 +12,7 @@ import (
 )
 
 type SetMetaDataResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 type SetMetaDataInput struct {
@@ -20,18 +20,21 @@ type SetMetaDataInput struct {
 }
 
 // SetMetaData sets the MetaData on the specified Storage Share
-func (c Client) SetMetaData(ctx context.Context, shareName string, input SetMetaDataInput) (resp SetMetaDataResponse, err error) {
+func (c Client) SetMetaData(ctx context.Context, shareName string, input SetMetaDataInput) (result SetMetaDataResponse, err error) {
 
 	if shareName == "" {
-		return resp, fmt.Errorf("`shareName` cannot be an empty string")
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
 	}
 
 	if strings.ToLower(shareName) != shareName {
-		return resp, fmt.Errorf("`shareName` must be a lower-cased string")
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
 	}
 
-	if err := metadata.Validate(input.MetaData); err != nil {
-		return resp, fmt.Errorf("`metadata` is not valid: %v", err)
+	if err = metadata.Validate(input.MetaData); err != nil {
+		err = fmt.Errorf("`metadata` is not valid: %+v", err)
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -52,7 +55,11 @@ func (c Client) SetMetaData(ctx context.Context, shareName string, input SetMeta
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/file/shares/properties_get.go
+++ b/storage/2023-11-03/file/shares/properties_get.go
@@ -3,12 +3,12 @@ package shares
 import (
 	"context"
 	"fmt"
-	"github.com/tombuildsstuff/giovanni/storage/internal/metadata"
 	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/tombuildsstuff/giovanni/storage/internal/metadata"
 )
 
 type GetPropertiesResult struct {

--- a/storage/2023-11-03/file/shares/properties_set.go
+++ b/storage/2023-11-03/file/shares/properties_set.go
@@ -17,22 +17,22 @@ type ShareProperties struct {
 }
 
 type SetPropertiesResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // SetProperties lets you update the Quota for the specified Storage Share
-func (c Client) SetProperties(ctx context.Context, shareName string, properties ShareProperties) (resp SetPropertiesResponse, err error) {
+func (c Client) SetProperties(ctx context.Context, shareName string, properties ShareProperties) (result SetPropertiesResponse, err error) {
 
 	if shareName == "" {
-		return resp, fmt.Errorf("`shareName` cannot be an empty string")
+		return result, fmt.Errorf("`shareName` cannot be an empty string")
 	}
 
 	if strings.ToLower(shareName) != shareName {
-		return resp, fmt.Errorf("`shareName` must be a lower-cased string")
+		return result, fmt.Errorf("`shareName` must be a lower-cased string")
 	}
 
 	if newQuotaGB := properties.QuotaInGb; newQuotaGB != nil && (*newQuotaGB <= 0 || *newQuotaGB > 102400) {
-		return resp, fmt.Errorf("`newQuotaGB` must be greater than 0, and less than/equal to 100TB (102400 GB)")
+		return result, fmt.Errorf("`newQuotaGB` must be greater than 0, and less than/equal to 100TB (102400 GB)")
 	}
 
 	opts := client.RequestOptions{
@@ -53,7 +53,11 @@ func (c Client) SetProperties(ctx context.Context, shareName string, properties 
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/file/shares/snapshot_delete.go
+++ b/storage/2023-11-03/file/shares/snapshot_delete.go
@@ -11,22 +11,22 @@ import (
 )
 
 type DeleteSnapshotResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // DeleteSnapshot deletes the specified Snapshot of a Storage Share
-func (c Client) DeleteSnapshot(ctx context.Context, accountName, shareName string, shareSnapshot string) (resp DeleteSnapshotResponse, err error) {
+func (c Client) DeleteSnapshot(ctx context.Context, accountName, shareName string, shareSnapshot string) (result DeleteSnapshotResponse, err error) {
 
 	if shareName == "" {
-		return resp, fmt.Errorf("`shareName` cannot be an empty string")
+		return result, fmt.Errorf("`shareName` cannot be an empty string")
 	}
 
 	if strings.ToLower(shareName) != shareName {
-		return resp, fmt.Errorf("`shareName` must be a lower-cased string")
+		return result, fmt.Errorf("`shareName` must be a lower-cased string")
 	}
 
 	if shareSnapshot == "" {
-		return resp, fmt.Errorf("`shareSnapshot` cannot be an empty string")
+		return result, fmt.Errorf("`shareSnapshot` cannot be an empty string")
 	}
 
 	opts := client.RequestOptions{
@@ -47,7 +47,11 @@ func (c Client) DeleteSnapshot(ctx context.Context, accountName, shareName strin
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/file/shares/snapshot_get.go
+++ b/storage/2023-11-03/file/shares/snapshot_get.go
@@ -3,12 +3,12 @@ package shares
 import (
 	"context"
 	"fmt"
-	"github.com/tombuildsstuff/giovanni/storage/internal/metadata"
 	"net/http"
 	"strings"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/client"
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/tombuildsstuff/giovanni/storage/internal/metadata"
 )
 
 type GetSnapshotPropertiesResponse struct {

--- a/storage/2023-11-03/queue/messages/delete.go
+++ b/storage/2023-11-03/queue/messages/delete.go
@@ -11,7 +11,7 @@ import (
 )
 
 type DeleteResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 type DeleteInput struct {
@@ -19,22 +19,22 @@ type DeleteInput struct {
 }
 
 // Delete deletes a specific message
-func (c Client) Delete(ctx context.Context, queueName, messageID string, input DeleteInput) (resp DeleteResponse, err error) {
+func (c Client) Delete(ctx context.Context, queueName, messageID string, input DeleteInput) (result DeleteResponse, err error) {
 
 	if queueName == "" {
-		return resp, fmt.Errorf("`queueName` cannot be an empty string")
+		return result, fmt.Errorf("`queueName` cannot be an empty string")
 	}
 
 	if strings.ToLower(queueName) != queueName {
-		return resp, fmt.Errorf("`queueName` must be a lower-cased string")
+		return result, fmt.Errorf("`queueName` must be a lower-cased string")
 	}
 
 	if messageID == "" {
-		return resp, fmt.Errorf("`messageID` cannot be an empty string")
+		return result, fmt.Errorf("`messageID` cannot be an empty string")
 	}
 
 	if input.PopReceipt == "" {
-		return resp, fmt.Errorf("`input.PopReceipt` cannot be an empty string")
+		return result, fmt.Errorf("`input.PopReceipt` cannot be an empty string")
 	}
 
 	opts := client.RequestOptions{
@@ -55,7 +55,11 @@ func (c Client) Delete(ctx context.Context, queueName, messageID string, input D
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/queue/messages/models.go
+++ b/storage/2023-11-03/queue/messages/models.go
@@ -1,7 +1,7 @@
 package messages
 
 import (
-	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"net/http"
 )
 
 type QueueMessage struct {
@@ -9,7 +9,7 @@ type QueueMessage struct {
 }
 
 type QueueMessagesListResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 
 	QueueMessages *[]QueueMessageResponse `xml:"QueueMessage"`
 }

--- a/storage/2023-11-03/queue/messages/update.go
+++ b/storage/2023-11-03/queue/messages/update.go
@@ -30,20 +30,20 @@ type UpdateInput struct {
 }
 
 type UpdateResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Update updates an existing message based on it's Pop Receipt
-func (c Client) Update(ctx context.Context, queueName string, messageID string, input UpdateInput) (resp UpdateResponse, err error) {
+func (c Client) Update(ctx context.Context, queueName string, messageID string, input UpdateInput) (result UpdateResponse, err error) {
 
 	if queueName == "" {
-		return resp, fmt.Errorf("`queueName` cannot be an empty string")
+		return result, fmt.Errorf("`queueName` cannot be an empty string")
 	}
 	if strings.ToLower(queueName) != queueName {
-		return resp, fmt.Errorf("`queueName` must be a lower-cased string")
+		return result, fmt.Errorf("`queueName` must be a lower-cased string")
 	}
 	if input.PopReceipt == "" {
-		return resp, fmt.Errorf("`input.PopReceipt` cannot be an empty string")
+		return result, fmt.Errorf("`input.PopReceipt` cannot be an empty string")
 	}
 
 	opts := client.RequestOptions{
@@ -68,7 +68,7 @@ func (c Client) Update(ctx context.Context, queueName string, messageID string, 
 		MessageText: input.Message,
 	})
 	if err != nil {
-		return resp, fmt.Errorf("marshalling request: %v", err)
+		return result, fmt.Errorf("marshalling request: %+v", err)
 	}
 
 	body := xml.Header + string(marshalledMsg)
@@ -76,7 +76,11 @@ func (c Client) Update(ctx context.Context, queueName string, messageID string, 
 	req.ContentLength = int64(len(body))
 	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/queue/queues/create.go
+++ b/storage/2023-11-03/queue/queues/create.go
@@ -16,22 +16,22 @@ type CreateInput struct {
 }
 
 type CreateResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Create creates the specified Queue within the specified Storage Account
-func (c Client) Create(ctx context.Context, queueName string, input CreateInput) (resp CreateResponse, err error) {
+func (c Client) Create(ctx context.Context, queueName string, input CreateInput) (result CreateResponse, err error) {
 
 	if queueName == "" {
-		return resp, fmt.Errorf("`queueName` cannot be an empty string")
+		return result, fmt.Errorf("`queueName` cannot be an empty string")
 	}
 
 	if strings.ToLower(queueName) != queueName {
-		return resp, fmt.Errorf("`queueName` must be a lower-cased string")
+		return result, fmt.Errorf("`queueName` must be a lower-cased string")
 	}
 
 	if err := metadata.Validate(input.MetaData); err != nil {
-		return resp, fmt.Errorf("`metadata` is not valid: %s", err)
+		return result, fmt.Errorf("`metadata` is not valid: %s", err)
 	}
 
 	opts := client.RequestOptions{
@@ -52,7 +52,11 @@ func (c Client) Create(ctx context.Context, queueName string, input CreateInput)
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/queue/queues/delete.go
+++ b/storage/2023-11-03/queue/queues/delete.go
@@ -10,18 +10,18 @@ import (
 )
 
 type DeleteResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Delete deletes the specified Queue within the specified Storage Account
-func (c Client) Delete(ctx context.Context, queueName string) (resp DeleteResponse, err error) {
+func (c Client) Delete(ctx context.Context, queueName string) (result DeleteResponse, err error) {
 
 	if queueName == "" {
-		return resp, fmt.Errorf("`queueName` cannot be an empty string")
+		return result, fmt.Errorf("`queueName` cannot be an empty string")
 	}
 
 	if strings.ToLower(queueName) != queueName {
-		return resp, fmt.Errorf("`queueName` must be a lower-cased string")
+		return result, fmt.Errorf("`queueName` must be a lower-cased string")
 	}
 
 	opts := client.RequestOptions{
@@ -40,7 +40,11 @@ func (c Client) Delete(ctx context.Context, queueName string) (resp DeleteRespon
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/queue/queues/metadata_set.go
+++ b/storage/2023-11-03/queue/queues/metadata_set.go
@@ -12,7 +12,7 @@ import (
 )
 
 type SetMetaDataResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 type SetMetaDataInput struct {
@@ -20,18 +20,18 @@ type SetMetaDataInput struct {
 }
 
 // SetMetaData returns the metadata for this Queue
-func (c Client) SetMetaData(ctx context.Context, queueName string, input SetMetaDataInput) (resp SetMetaDataResponse, err error) {
+func (c Client) SetMetaData(ctx context.Context, queueName string, input SetMetaDataInput) (result SetMetaDataResponse, err error) {
 
 	if queueName == "" {
-		return resp, fmt.Errorf("`queueName` cannot be an empty string")
+		return result, fmt.Errorf("`queueName` cannot be an empty string")
 	}
 
 	if strings.ToLower(queueName) != queueName {
-		return resp, fmt.Errorf("`queueName` must be a lower-cased string")
+		return result, fmt.Errorf("`queueName` must be a lower-cased string")
 	}
 
 	if err := metadata.Validate(input.MetaData); err != nil {
-		return resp, fmt.Errorf("`metadata` is not valid: %v", err)
+		return result, fmt.Errorf("`metadata` is not valid: %+v", err)
 	}
 
 	opts := client.RequestOptions{
@@ -52,7 +52,11 @@ func (c Client) SetMetaData(ctx context.Context, queueName string, input SetMeta
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/queue/queues/models.go
+++ b/storage/2023-11-03/queue/queues/models.go
@@ -36,7 +36,7 @@ type Cors struct {
 type CorsRule struct {
 	AllowedOrigins  string `xml:"AllowedOrigins"`
 	AllowedMethods  string `xml:"AllowedMethods"`
-	AllowedHeaders  string `xml:"AllowedHeaders`
+	AllowedHeaders  string `xml:"AllowedHeaders"`
 	ExposedHeaders  string `xml:"ExposedHeaders"`
 	MaxAgeInSeconds int    `xml:"MaxAgeInSeconds"`
 }

--- a/storage/2023-11-03/queue/queues/properties_get.go
+++ b/storage/2023-11-03/queue/queues/properties_get.go
@@ -11,11 +11,11 @@ import (
 
 type GetStorageServicePropertiesResponse struct {
 	StorageServiceProperties
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // GetServiceProperties gets the properties for this queue
-func (c Client) GetServiceProperties(ctx context.Context) (resp GetStorageServicePropertiesResponse, err error) {
+func (c Client) GetServiceProperties(ctx context.Context) (result GetStorageServicePropertiesResponse, err error) {
 
 	opts := client.RequestOptions{
 		ContentType: "application/xml; charset=utf-8",
@@ -33,17 +33,20 @@ func (c Client) GetServiceProperties(ctx context.Context) (resp GetStorageServic
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+
+		err = resp.Unmarshal(&result)
+		if err != nil {
+			err = fmt.Errorf("unmarshalling response: %+v", err)
+			return
+		}
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return
-	}
-
-	if resp.HttpResponse != nil {
-		err = resp.HttpResponse.Unmarshal(&resp)
-		if err != nil {
-			return resp, fmt.Errorf("unmarshalling respnse: %v", err)
-		}
 	}
 
 	return

--- a/storage/2023-11-03/queue/queues/properties_set.go
+++ b/storage/2023-11-03/queue/queues/properties_set.go
@@ -14,7 +14,7 @@ import (
 )
 
 type SetStorageServicePropertiesResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 type SetStorageServicePropertiesInput struct {
@@ -22,7 +22,7 @@ type SetStorageServicePropertiesInput struct {
 }
 
 // SetServiceProperties sets the properties for this queue
-func (c Client) SetServiceProperties(ctx context.Context, input SetStorageServicePropertiesInput) (resp SetStorageServicePropertiesResponse, err error) {
+func (c Client) SetServiceProperties(ctx context.Context, input SetStorageServicePropertiesInput) (result SetStorageServicePropertiesResponse, err error) {
 
 	opts := client.RequestOptions{
 		ContentType: "application/xml; charset=utf-8",
@@ -42,14 +42,18 @@ func (c Client) SetServiceProperties(ctx context.Context, input SetStorageServic
 
 	marshalledProps, err := xml.Marshal(&input.Properties)
 	if err != nil {
-		return resp, fmt.Errorf("marshalling request: %v", err)
+		return result, fmt.Errorf("marshalling request: %+v", err)
 	}
 	body := xml.Header + string(marshalledProps)
 	req.Body = io.NopCloser(bytes.NewReader([]byte(body)))
 	req.ContentLength = int64(len(body))
 	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/table/entities/delete.go
+++ b/storage/2023-11-03/table/entities/delete.go
@@ -20,22 +20,22 @@ type DeleteEntityInput struct {
 }
 
 type DeleteEntityResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Delete deletes an existing entity in a table.
-func (c Client) Delete(ctx context.Context, tableName string, input DeleteEntityInput) (resp DeleteEntityResponse, err error) {
+func (c Client) Delete(ctx context.Context, tableName string, input DeleteEntityInput) (result DeleteEntityResponse, err error) {
 
 	if tableName == "" {
-		return resp, fmt.Errorf("`tableName` cannot be an empty string")
+		return result, fmt.Errorf("`tableName` cannot be an empty string")
 	}
 
 	if input.PartitionKey == "" {
-		return resp, fmt.Errorf("`input.PartitionKey` cannot be an empty string")
+		return result, fmt.Errorf("`input.PartitionKey` cannot be an empty string")
 	}
 
 	if input.RowKey == "" {
-		return resp, fmt.Errorf("`input.RowKey` cannot be an empty string")
+		return result, fmt.Errorf("`input.RowKey` cannot be an empty string")
 	}
 
 	opts := client.RequestOptions{
@@ -54,7 +54,11 @@ func (c Client) Delete(ctx context.Context, tableName string, input DeleteEntity
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/table/entities/insert.go
+++ b/storage/2023-11-03/table/entities/insert.go
@@ -28,21 +28,21 @@ type InsertEntityInput struct {
 }
 
 type InsertResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Insert inserts a new entity into a table.
-func (c Client) Insert(ctx context.Context, tableName string, input InsertEntityInput) (resp InsertResponse, err error) {
+func (c Client) Insert(ctx context.Context, tableName string, input InsertEntityInput) (result InsertResponse, err error) {
 	if tableName == "" {
-		return resp, fmt.Errorf("`tableName` cannot be an empty string")
+		return result, fmt.Errorf("`tableName` cannot be an empty string")
 	}
 
 	if input.PartitionKey == "" {
-		return resp, fmt.Errorf("`input.PartitionKey` cannot be an empty string")
+		return result, fmt.Errorf("`input.PartitionKey` cannot be an empty string")
 	}
 
 	if input.RowKey == "" {
-		return resp, fmt.Errorf("`input.RowKey` cannot be an empty string")
+		return result, fmt.Errorf("`input.RowKey` cannot be an empty string")
 	}
 
 	opts := client.RequestOptions{
@@ -68,10 +68,14 @@ func (c Client) Insert(ctx context.Context, tableName string, input InsertEntity
 
 	err = req.Marshal(&input.Entity)
 	if err != nil {
-		return resp, fmt.Errorf("marshalling request: %v", err)
+		return result, fmt.Errorf("marshalling request: %+v", err)
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/table/entities/insert_or_merge.go
+++ b/storage/2023-11-03/table/entities/insert_or_merge.go
@@ -25,22 +25,22 @@ type InsertOrMergeEntityInput struct {
 }
 
 type InsertOrMergeResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // InsertOrMerge updates an existing entity or inserts a new entity if it does not exist in the table.
 // Because this operation can insert or update an entity, it is also known as an upsert operation.
-func (c Client) InsertOrMerge(ctx context.Context, tableName string, input InsertOrMergeEntityInput) (resp InsertOrMergeResponse, err error) {
+func (c Client) InsertOrMerge(ctx context.Context, tableName string, input InsertOrMergeEntityInput) (result InsertOrMergeResponse, err error) {
 	if tableName == "" {
-		return resp, fmt.Errorf("`tableName` cannot be an empty string")
+		return result, fmt.Errorf("`tableName` cannot be an empty string")
 	}
 
 	if input.PartitionKey == "" {
-		return resp, fmt.Errorf("`input.PartitionKey` cannot be an empty string")
+		return result, fmt.Errorf("`input.PartitionKey` cannot be an empty string")
 	}
 
 	if input.RowKey == "" {
-		return resp, fmt.Errorf("`input.RowKey` cannot be an empty string")
+		return result, fmt.Errorf("`input.RowKey` cannot be an empty string")
 	}
 
 	opts := client.RequestOptions{
@@ -64,10 +64,14 @@ func (c Client) InsertOrMerge(ctx context.Context, tableName string, input Inser
 
 	err = req.Marshal(&input.Entity)
 	if err != nil {
-		return resp, fmt.Errorf("marshalling request: %v", err)
+		return result, fmt.Errorf("marshalling request: %+v", err)
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/table/entities/insert_or_replace.go
+++ b/storage/2023-11-03/table/entities/insert_or_replace.go
@@ -25,22 +25,22 @@ type InsertOrReplaceEntityInput struct {
 }
 
 type InsertOrReplaceResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // InsertOrReplace replaces an existing entity or inserts a new entity if it does not exist in the table.
 // Because this operation can insert or update an entity, it is also known as an upsert operation.
-func (c Client) InsertOrReplace(ctx context.Context, tableName string, input InsertOrReplaceEntityInput) (resp InsertOrReplaceResponse, err error) {
+func (c Client) InsertOrReplace(ctx context.Context, tableName string, input InsertOrReplaceEntityInput) (result InsertOrReplaceResponse, err error) {
 	if tableName == "" {
-		return resp, fmt.Errorf("`tableName` cannot be an empty string")
+		return result, fmt.Errorf("`tableName` cannot be an empty string")
 	}
 
 	if input.PartitionKey == "" {
-		return resp, fmt.Errorf("`input.PartitionKey` cannot be an empty string")
+		return result, fmt.Errorf("`input.PartitionKey` cannot be an empty string")
 	}
 
 	if input.RowKey == "" {
-		return resp, fmt.Errorf("`input.RowKey` cannot be an empty string")
+		return result, fmt.Errorf("`input.RowKey` cannot be an empty string")
 	}
 
 	opts := client.RequestOptions{
@@ -64,10 +64,14 @@ func (c Client) InsertOrReplace(ctx context.Context, tableName string, input Ins
 
 	err = req.Marshal(&input.Entity)
 	if err != nil {
-		return resp, fmt.Errorf("marshalling request: %v", err)
+		return result, fmt.Errorf("marshalling request: %+v", err)
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/table/tables/acl_set.go
+++ b/storage/2023-11-03/table/tables/acl_set.go
@@ -17,13 +17,14 @@ type setAcl struct {
 }
 
 type SetACLResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // SetACL sets the specified Access Control List for the specified Table
-func (c Client) SetACL(ctx context.Context, tableName string, acls []SignedIdentifier) (resp SetACLResponse, err error) {
+func (c Client) SetACL(ctx context.Context, tableName string, acls []SignedIdentifier) (result SetACLResponse, err error) {
 	if tableName == "" {
-		return resp, fmt.Errorf("`tableName` cannot be an empty string")
+		err = fmt.Errorf("`tableName` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -44,10 +45,15 @@ func (c Client) SetACL(ctx context.Context, tableName string, acls []SignedIdent
 
 	err = req.Marshal(setAcl{SignedIdentifiers: acls})
 	if err != nil {
-		return resp, fmt.Errorf("marshalling request: %+v", err)
+		err = fmt.Errorf("marshalling request: %+v", err)
+		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/table/tables/create.go
+++ b/storage/2023-11-03/table/tables/create.go
@@ -14,13 +14,14 @@ type createTableRequest struct {
 }
 
 type CreateTableResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Create creates a new table in the storage account.
-func (c Client) Create(ctx context.Context, tableName string) (resp CreateTableResponse, err error) {
+func (c Client) Create(ctx context.Context, tableName string) (result CreateTableResponse, err error) {
 	if tableName == "" {
-		return resp, fmt.Errorf("`tableName` cannot be an empty string")
+		err = fmt.Errorf("`tableName` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -41,10 +42,14 @@ func (c Client) Create(ctx context.Context, tableName string) (resp CreateTableR
 
 	err = req.Marshal(&createTableRequest{TableName: tableName})
 	if err != nil {
-		return resp, fmt.Errorf("marshalling request")
+		return result, fmt.Errorf("marshalling request")
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/table/tables/delete.go
+++ b/storage/2023-11-03/table/tables/delete.go
@@ -10,13 +10,14 @@ import (
 )
 
 type DeleteTableResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Delete deletes the specified table and any data it contains.
-func (c Client) Delete(ctx context.Context, tableName string) (resp DeleteTableResponse, err error) {
+func (c Client) Delete(ctx context.Context, tableName string) (result DeleteTableResponse, err error) {
 	if tableName == "" {
-		return resp, fmt.Errorf("`tableName` cannot be an empty string")
+		err = fmt.Errorf("`tableName` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -35,7 +36,11 @@ func (c Client) Delete(ctx context.Context, tableName string) (resp DeleteTableR
 		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/2023-11-03/table/tables/exists.go
+++ b/storage/2023-11-03/table/tables/exists.go
@@ -10,13 +10,14 @@ import (
 )
 
 type TableExistsResponse struct {
-	HttpResponse *client.Response
+	HttpResponse *http.Response
 }
 
 // Exists checks that the specified table exists
-func (c Client) Exists(ctx context.Context, tableName string) (resp TableExistsResponse, err error) {
+func (c Client) Exists(ctx context.Context, tableName string) (result TableExistsResponse, err error) {
 	if tableName == "" {
-		return resp, fmt.Errorf("`tableName` cannot be an empty string")
+		err = fmt.Errorf("`tableName` cannot be an empty string")
+		return
 	}
 
 	opts := client.RequestOptions{
@@ -37,10 +38,15 @@ func (c Client) Exists(ctx context.Context, tableName string) (resp TableExistsR
 
 	err = req.Marshal(&createTableRequest{TableName: tableName})
 	if err != nil {
-		return resp, fmt.Errorf("marshalling request")
+		err = fmt.Errorf("marshalling request")
+		return
 	}
 
-	resp.HttpResponse, err = req.Execute(ctx)
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)
 		return

--- a/storage/internal/metadata/parse.go
+++ b/storage/internal/metadata/parse.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-// ParseFromHeaders parses the meta data from the headers
+// ParseFromHeaders parses the metadata from the headers
 func ParseFromHeaders(headers http.Header) map[string]string {
 	metaData := make(map[string]string, 0)
 	prefix := "x-ms-meta-"


### PR DESCRIPTION
- `HttpResponse` fields to be vanilla `*http.Response`
- Embed all response structs for continuity
- General tidy up, remove shadowed vars, improve error handling
- Fix a typo'd struct tag in both SDK versions
- Export `GetPropertiesInput{}.Action` in `storage/2023-11-03/datalakestore/paths/properties_get.go`