### PR TITLE
bugfix: add `x-ms-file-request-intent` header for the Files API when authenticating using OAuth

### DIFF
--- a/storage/2023-11-03/file/directories/client.go
+++ b/storage/2023-11-03/file/directories/client.go
@@ -1,8 +1,11 @@
 package directories
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/dataplane/storage"
 )
 
@@ -16,6 +19,20 @@ func NewWithBaseUri(baseUri string) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("building base client: %+v", err)
 	}
+
+	baseClient.Client.AuthorizeRequest = func(ctx context.Context, req *http.Request, authorizer auth.Authorizer) error {
+		if err := auth.SetAuthHeader(ctx, req, authorizer); err != nil {
+			return fmt.Errorf("authorizing request: %+v", err)
+		}
+
+		// Only set this header if OAuth is being used (i.e. not shared key authentication)
+		if _, ok := authorizer.(*auth.SharedKeyAuthorizer); !ok {
+			req.Header.Set("x-ms-file-request-intent", "backup")
+		}
+
+		return nil
+	}
+
 	return &Client{
 		Client: baseClient,
 	}, nil

--- a/storage/2023-11-03/file/files/client.go
+++ b/storage/2023-11-03/file/files/client.go
@@ -1,8 +1,11 @@
 package files
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/dataplane/storage"
 )
 
@@ -16,6 +19,20 @@ func NewWithBaseUri(baseUri string) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("building base client: %+v", err)
 	}
+
+	baseClient.Client.AuthorizeRequest = func(ctx context.Context, req *http.Request, authorizer auth.Authorizer) error {
+		if err := auth.SetAuthHeader(ctx, req, authorizer); err != nil {
+			return fmt.Errorf("authorizing request: %+v", err)
+		}
+
+		// Only set this header if OAuth is being used (i.e. not shared key authentication)
+		if _, ok := authorizer.(*auth.SharedKeyAuthorizer); !ok {
+			req.Header.Set("x-ms-file-request-intent", "backup")
+		}
+
+		return nil
+	}
+
 	return &Client{
 		Client: baseClient,
 	}, nil


### PR DESCRIPTION
Intentionally avoid setting this header when using shared key authentication, as the docs are ambiguous and it will avoid breaking existing users. The header seems to be required regardless of RBAC permissions granted.

<img width="762" alt="Screenshot 2024-03-01 at 03 12 30" src="https://github.com/tombuildsstuff/giovanni/assets/251987/db6a6475-3a08-407b-bead-4c47c34e0a4a">
<br>  <br>  

<img width="640" alt="Screenshot 2024-03-01 at 03 14 05" src="https://github.com/tombuildsstuff/giovanni/assets/251987/0acb2909-59c9-4f44-b14d-5e2bb93b5a05">

