### PR TITLE
bugfix: don't use req.Marshal to encode a binary payload…

### DIFF
--- a/storage/2023-11-03/blob/blobs/get.go
+++ b/storage/2023-11-03/blob/blobs/get.go
@@ -68,13 +68,15 @@ func (c Client) Get(ctx context.Context, containerName, blobName string, input G
 	if resp != nil {
 		result.HttpResponse = resp.Response
 
-		respBody, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return result, fmt.Errorf("could not parse response body")
-		}
-		resp.Body.Close()
+		if resp.Body != nil {
+			defer resp.Body.Close()
+			respBody, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return result, fmt.Errorf("could not parse response body")
+			}
 
-		result.Contents = &respBody
+			result.Contents = &respBody
+		}
 	}
 	if err != nil {
 		err = fmt.Errorf("executing request: %+v", err)

--- a/storage/2023-11-03/blob/blobs/put_block_blob.go
+++ b/storage/2023-11-03/blob/blobs/put_block_blob.go
@@ -1,8 +1,10 @@
 package blobs
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -78,10 +80,9 @@ func (c Client) PutBlockBlob(ctx context.Context, containerName, blobName string
 		return
 	}
 
-	err = req.Marshal(input.Content)
-	if err != nil {
-		err = fmt.Errorf("marshalling request: %+v", err)
-		return
+	if input.Content != nil {
+		req.ContentLength = int64(len(*input.Content))
+		req.Body = io.NopCloser(bytes.NewReader(*input.Content))
 	}
 
 	var resp *client.Response


### PR DESCRIPTION
… since this incorrectly assumes source type (which is actually a byteslice) from content-type

related: https://github.com/hashicorp/terraform-provider-azurerm/issues/25333