### PR TITLE
share change `deleteSnapshot` from bool to enum, to support `include` and `include-leased`

### DIFF
--- a/storage/2023-11-03/file/shares/delete.go
+++ b/storage/2023-11-03/file/shares/delete.go
@@ -14,8 +14,15 @@ type DeleteResponse struct {
 	HttpResponse *http.Response
 }
 
+type DeleteSnapshotsType string
+
+const (
+	DeleteSnapshotsInclude       DeleteSnapshotsType = "include"
+	DeleteSnapshotsIncludeLeased DeleteSnapshotsType = "leased"
+)
+
 type DeleteInput struct {
-	DeleteSnapshots bool
+	DeleteSnapshotsType DeleteSnapshotsType
 }
 
 // Delete deletes the specified Storage Share from within a Storage Account
@@ -37,7 +44,7 @@ func (c Client) Delete(ctx context.Context, shareName string, input DeleteInput)
 		},
 		HttpMethod: http.MethodDelete,
 		OptionsObject: DeleteOptions{
-			deleteSnapshots: input.DeleteSnapshots,
+			deleteSnapshotsType: input.DeleteSnapshotsType,
 		},
 		Path: fmt.Sprintf("/%s", shareName),
 	}
@@ -61,13 +68,13 @@ func (c Client) Delete(ctx context.Context, shareName string, input DeleteInput)
 }
 
 type DeleteOptions struct {
-	deleteSnapshots bool
+	deleteSnapshotsType DeleteSnapshotsType
 }
 
 func (d DeleteOptions) ToHeaders() *client.Headers {
 	headers := &client.Headers{}
-	if d.deleteSnapshots {
-		headers.Append("x-ms-delete-snapshots", "include")
+	if d.deleteSnapshotsType != "" {
+		headers.Append("x-ms-delete-snapshots", string(d.deleteSnapshotsType))
 	}
 	return headers
 }

--- a/storage/2023-11-03/file/shares/lifecycle_test.go
+++ b/storage/2023-11-03/file/shares/lifecycle_test.go
@@ -175,7 +175,7 @@ func TestSharesLifecycle(t *testing.T) {
 		t.Fatalf("Expected 2 identifiers but got %d", len(acls.SignedIdentifiers))
 	}
 
-	_, err = sharesClient.Delete(ctx, shareName, DeleteInput{DeleteSnapshots: false})
+	_, err = sharesClient.Delete(ctx, shareName, DeleteInput{})
 	if err != nil {
 		t.Fatalf("Error deleting Share: %s", err)
 	}
@@ -329,7 +329,7 @@ func TestSharesLifecycleLargeQuota(t *testing.T) {
 		t.Fatalf("Expected 2 identifiers but got %d", len(acls.SignedIdentifiers))
 	}
 
-	_, err = sharesClient.Delete(ctx, shareName, DeleteInput{DeleteSnapshots: false})
+	_, err = sharesClient.Delete(ctx, shareName, DeleteInput{})
 	if err != nil {
 		t.Fatalf("Error deleting Share: %s", err)
 	}
@@ -380,7 +380,7 @@ func TestSharesLifecycleNFSProtocol(t *testing.T) {
 		t.Fatalf(`Expected enabled protocol to be "NFS" but got: %q`, share.EnabledProtocol)
 	}
 
-	_, err = sharesClient.Delete(ctx, shareName, DeleteInput{DeleteSnapshots: false})
+	_, err = sharesClient.Delete(ctx, shareName, DeleteInput{})
 	if err != nil {
 		t.Fatalf("Error deleting Share: %s", err)
 	}


### PR DESCRIPTION
This is a breaking change.

Reference: https://learn.microsoft.com/en-us/rest/api/storageservices/delete-share#request-headers

Related issue: https://github.com/hashicorp/terraform-provider-azurerm/issues/26408