### PR TITLE
share change deleteSnapshot enum correct value of include-leased

### DIFF
--- a/storage/2023-11-03/file/shares/delete.go
+++ b/storage/2023-11-03/file/shares/delete.go
@@ -18,7 +18,7 @@ type DeleteSnapshotsType string
 
 const (
 	DeleteSnapshotsInclude       DeleteSnapshotsType = "include"
-	DeleteSnapshotsIncludeLeased DeleteSnapshotsType = "leased"
+	DeleteSnapshotsIncludeLeased DeleteSnapshotsType = "include-leased"
 )
 
 type DeleteInput struct {


### PR DESCRIPTION
This PR fixes a typo in https://github.com/tombuildsstuff/giovanni/pull/119/.

The API definition can be found at: https://github.com/magodo/azure-rest-api-specs/blob/d61e5beea1bac338cf3ef7c57560b4fc74f96b88/specification/storage/data-plane/Microsoft.FileStorage/stable/2025-01-05/file.json#L7151-L7154

Reference: https://github.com/hashicorp/terraform-provider-azurerm/issues/26408